### PR TITLE
refactor: extract stream_ioc_objects generator for lazy NDJSON streaming. Closes #1443

### DIFF
--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -45,6 +45,7 @@ from api.views.utils import (
     aggregate_iocs_by_asn,
     build_feed_dict,
     save_request_source,
+    stream_ioc_objects,
 )
 from greedybear.consts import SHARE_TOKEN_SALT, TRENDING_FEEDS_DATA_VERSION_KEY
 from greedybear.cronjobs.repositories import TrendingBucketRepository
@@ -186,8 +187,7 @@ class BaseFeedView(RequestLoggingMixin, CachedResponseMixin, APIView):
             verbose = self.request_params.get("verbose", False)
 
             def stream_iocs():
-                feed = build_feed_dict(iocs_queryset, verbose, include_sensors=self.include_sensors)
-                for ioc in feed["iocs"]:
+                for ioc in stream_ioc_objects(iocs_queryset, verbose=verbose, include_sensors=self.include_sensors):
                     yield json.dumps(ioc, default=str) + "\n"
 
             return StreamingHttpResponse(stream_iocs(), content_type="application/x-ndjson")

--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -190,7 +190,10 @@ class BaseFeedView(RequestLoggingMixin, CachedResponseMixin, APIView):
                 for ioc in stream_ioc_objects(iocs_queryset, verbose=verbose, include_sensors=self.include_sensors):
                     yield json.dumps(ioc, default=str) + "\n"
 
-            return StreamingHttpResponse(stream_iocs(), content_type="application/x-ndjson")
+            response = StreamingHttpResponse(stream_iocs(), content_type="application/x-ndjson")
+            # tell nginx not to buffer this response so rows reach the client as they are produced
+            response["X-Accel-Buffering"] = "no"
+            return response
         renderer = RENDERERS_BY_FORMAT[self.request_params["format"]]()
         request.accepted_renderer = renderer
         request.accepted_media_type = renderer.media_type

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -122,6 +122,11 @@ def stream_ioc_objects(iocs, verbose=False, include_sensors=False):
         dict: A single JSON-serializable IOC dict.
     """
     required_fields = JSON_BASE_FIELDS + JSON_VERBOSE_FIELDS if verbose else JSON_BASE_FIELDS
+
+    # `tags_json` is annotated in get_queryset (only for JSON format) to avoid conflicting
+    # with the `tags` reverse FK on IOC. When the queryset comes from a repository method
+    # that does not annotate `tags_json` (e.g. the ML scoring path), exclude the field.
+    # `sensors_json` follows the same pattern and is only annotated for authenticated views.
     if isinstance(iocs, list):
         has_tags_annotation = bool(iocs) and hasattr(iocs[0], "tags_json")
         has_sensors_annotation = include_sensors and bool(iocs) and hasattr(iocs[0], "sensors_json")
@@ -135,6 +140,7 @@ def stream_ioc_objects(iocs, verbose=False, include_sensors=False):
     required_fields = tuple(f for f in required_fields if f != "credential_count" or has_credential_count)
     if has_sensors_annotation:
         required_fields = (*required_fields, "sensors_json")
+
     if isinstance(iocs, list):
         iocs_iter = (ioc_as_dict(ioc, set(required_fields)) for ioc in iocs)
     else:
@@ -142,6 +148,7 @@ def stream_ioc_objects(iocs, verbose=False, include_sensors=False):
 
     for ioc in iocs_iter:
         ioc_feed_type = [hp.lower() for hp in ioc.get("honeypot_names", []) if hp]
+
         data_ = ioc | {
             "first_seen": ioc["first_seen"].strftime("%Y-%m-%d"),
             "last_seen": ioc["last_seen"].strftime("%Y-%m-%d"),
@@ -151,6 +158,7 @@ def stream_ioc_objects(iocs, verbose=False, include_sensors=False):
             "tags": ioc.pop("tags_json", []),
             **({"sensors": ioc.pop("sensors_json", [])} if has_sensors_annotation else {}),
         }
+
         if not verbose:
             data_.pop("destination_ports", None)
         data_.pop("autonomous_system", None)

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -168,7 +168,20 @@ def stream_ioc_objects(iocs, verbose=False, include_sensors=False):
 
 
 def build_ioc_json_list(iocs, verbose=False, include_sensors=False) -> list[dict]:
-    """Shape a queryset (or list) of IOCs into the JSON feed row dicts"""
+    """Shape a queryset (or list) of IOCs into the JSON feed row dicts.
+
+    Pure data logic shared by the JSON renderer and the ML scoring path; it
+    builds the per-row dicts but performs no HTTP/encoding work. Eagerly
+    collects `stream_ioc_objects`; use that generator directly when the rows
+    can be consumed lazily.
+
+    Args:
+        iocs (QuerySet | list): Filtered IOCs to render.
+        verbose (bool): Include verbose fields (days_seen, destination_ports, firehol_categories).
+        include_sensors (bool): Emit a `sensors` array when the `sensors_json` annotation is present.
+
+    Returns: A list of JSON-serializable IOC dicts.
+    """
     json_list = list(stream_ioc_objects(iocs, verbose=verbose, include_sensors=include_sensors))
     logger.info(f"Number of feeds returned: {len(json_list)}")
     return json_list

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -146,7 +146,9 @@ def stream_ioc_objects(iocs, verbose=False, include_sensors=False):
     else:
         iocs_iter = iocs.values(*required_fields).iterator(chunk_size=2000)
 
+    count = 0
     for ioc in iocs_iter:
+        count += 1
         ioc_feed_type = [hp.lower() for hp in ioc.get("honeypot_names", []) if hp]
 
         data_ = ioc | {
@@ -165,6 +167,7 @@ def stream_ioc_objects(iocs, verbose=False, include_sensors=False):
         data_.pop("honeypot_names", None)
         data_.pop("id", None)
         yield data_
+    logger.info(f"Number of feeds returned: {count}")
 
 
 def build_ioc_json_list(iocs, verbose=False, include_sensors=False) -> list[dict]:
@@ -182,9 +185,7 @@ def build_ioc_json_list(iocs, verbose=False, include_sensors=False) -> list[dict
 
     Returns: A list of JSON-serializable IOC dicts.
     """
-    json_list = list(stream_ioc_objects(iocs, verbose=verbose, include_sensors=include_sensors))
-    logger.info(f"Number of feeds returned: {len(json_list)}")
-    return json_list
+    return list(stream_ioc_objects(iocs, verbose=verbose, include_sensors=include_sensors))
 
 
 def build_feed_dict(iocs, verbose=False, include_sensors=False) -> dict:

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -105,25 +105,23 @@ STIX_FIELDS = {
 }
 
 
-def build_ioc_json_list(iocs, verbose=False, include_sensors=False) -> list[dict]:
-    """Shape a queryset (or list) of IOCs into the JSON feed row dicts.
+def stream_ioc_objects(iocs, verbose=False, include_sensors=False):
+    """Yield shaped IOC dicts one at a time for memory-efficient NDJSON streaming.
 
-    Pure data logic shared by the JSON renderer and the ML scoring path; it
-    builds the per-row dicts but performs no HTTP/encoding work.
+    Contains the same shaping logic as build_ioc_json_list but yields each
+    IOC dict individually instead of collecting them into a list. This allows
+    StreamingHttpResponse to send each row to the client immediately without
+    loading the entire dataset into memory first.
 
     Args:
         iocs (QuerySet | list): Filtered IOCs to render.
         verbose (bool): Include verbose fields (days_seen, destination_ports, firehol_categories).
         include_sensors (bool): Emit a `sensors` array when the `sensors_json` annotation is present.
 
-    Returns: A list of JSON-serializable IOC dicts.
+    Yields:
+        dict: A single JSON-serializable IOC dict.
     """
     required_fields = JSON_BASE_FIELDS + JSON_VERBOSE_FIELDS if verbose else JSON_BASE_FIELDS
-
-    # `tags_json` is annotated in get_queryset (only for JSON format) to avoid conflicting
-    # with the `tags` reverse FK on IOC. When the queryset comes from a repository method
-    # that does not annotate `tags_json` (e.g. the ML scoring path), exclude the field.
-    # `sensors_json` follows the same pattern and is only annotated for authenticated views.
     if isinstance(iocs, list):
         has_tags_annotation = bool(iocs) and hasattr(iocs[0], "tags_json")
         has_sensors_annotation = include_sensors and bool(iocs) and hasattr(iocs[0], "sensors_json")
@@ -137,16 +135,13 @@ def build_ioc_json_list(iocs, verbose=False, include_sensors=False) -> list[dict
     required_fields = tuple(f for f in required_fields if f != "credential_count" or has_credential_count)
     if has_sensors_annotation:
         required_fields = (*required_fields, "sensors_json")
-
     if isinstance(iocs, list):
         iocs_iter = (ioc_as_dict(ioc, set(required_fields)) for ioc in iocs)
     else:
         iocs_iter = iocs.values(*required_fields).iterator(chunk_size=2000)
 
-    json_list = []
     for ioc in iocs_iter:
         ioc_feed_type = [hp.lower() for hp in ioc.get("honeypot_names", []) if hp]
-
         data_ = ioc | {
             "first_seen": ioc["first_seen"].strftime("%Y-%m-%d"),
             "last_seen": ioc["last_seen"].strftime("%Y-%m-%d"),
@@ -156,15 +151,17 @@ def build_ioc_json_list(iocs, verbose=False, include_sensors=False) -> list[dict
             "tags": ioc.pop("tags_json", []),
             **({"sensors": ioc.pop("sensors_json", [])} if has_sensors_annotation else {}),
         }
-
         if not verbose:
             data_.pop("destination_ports", None)
         data_.pop("autonomous_system", None)
         data_.pop("honeypot_names", None)
         data_.pop("id", None)
+        yield data_
 
-        json_list.append(data_)
 
+def build_ioc_json_list(iocs, verbose=False, include_sensors=False) -> list[dict]:
+    """Shape a queryset (or list) of IOCs into the JSON feed row dicts"""
+    json_list = list(stream_ioc_objects(iocs, verbose=verbose, include_sensors=include_sensors))
     logger.info(f"Number of feeds returned: {len(json_list)}")
     return json_list
 

--- a/configuration/nginx/http.conf
+++ b/configuration/nginx/http.conf
@@ -35,7 +35,7 @@ server {
         uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
 
         gzip on;
-        gzip_types application/json;
+        gzip_types application/json application/x-ndjson text/csv text/plain;
         gzip_min_length 1000;
     }
 

--- a/configuration/nginx/http.conf
+++ b/configuration/nginx/http.conf
@@ -31,6 +31,7 @@ server {
         uwsgi_pass_header           Authorization;
         uwsgi_pass_request_headers  on;
         uwsgi_read_timeout          600;
+        uwsgi_buffering             off;
         include                     uwsgi_params;
         uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
 

--- a/configuration/nginx/http.conf
+++ b/configuration/nginx/http.conf
@@ -31,7 +31,6 @@ server {
         uwsgi_pass_header           Authorization;
         uwsgi_pass_request_headers  on;
         uwsgi_read_timeout          600;
-        uwsgi_buffering             off;
         include                     uwsgi_params;
         uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
 

--- a/configuration/nginx/https.conf
+++ b/configuration/nginx/https.conf
@@ -47,7 +47,6 @@ server {
         uwsgi_pass_header           Authorization;
         uwsgi_pass_request_headers  on;
         uwsgi_read_timeout          600;
-        uwsgi_buffering             off;
         include                     uwsgi_params;
         uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
 

--- a/configuration/nginx/https.conf
+++ b/configuration/nginx/https.conf
@@ -51,7 +51,7 @@ server {
         uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
 
         gzip on;
-        gzip_types application/json;
+        gzip_types application/json application/x-ndjson text/csv text/plain;
         gzip_min_length 1000;
     }
 

--- a/configuration/nginx/https.conf
+++ b/configuration/nginx/https.conf
@@ -47,6 +47,7 @@ server {
         uwsgi_pass_header           Authorization;
         uwsgi_pass_request_headers  on;
         uwsgi_read_timeout          600;
+        uwsgi_buffering             off;
         include                     uwsgi_params;
         uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
 

--- a/tests/api/views/test_feeds_view.py
+++ b/tests/api/views/test_feeds_view.py
@@ -36,6 +36,7 @@ class FeedsViewTestCase(CustomTestCase):
     def test_200_ndjson_feed(self):
         response = self.client.get("/api/feeds/all/all/recent.ndjson")
         self.assertIn("application/x-ndjson", response.headers.get("Content-Type", ""))
+        self.assertEqual(response.headers.get("X-Accel-Buffering"), "no")
         self.assertEqual(response.status_code, 200)
         body = b"".join(response.streaming_content).decode("utf-8")
         lines = [line for line in body.split("\n") if line.strip()]

--- a/tests/api/views/test_utils.py
+++ b/tests/api/views/test_utils.py
@@ -1,0 +1,81 @@
+import types
+
+from django.db.models import F
+
+from api.views.utils import build_ioc_json_list, stream_ioc_objects
+from greedybear.models import IOC
+from tests import CustomTestCase
+
+
+class StreamIocObjectsTestCase(CustomTestCase):
+    def get_test_queryset(self):
+        from django.contrib.postgres.aggregates import ArrayAgg
+
+        return (
+            IOC.objects.annotate(value=F("name")).filter(honeypots__active=True).annotate(honeypot_names=ArrayAgg("honeypots__name", distinct=True)).distinct()
+        )
+
+    def test_stream_ioc_objects_returns_generator(self):
+        qs = self.get_test_queryset()
+        result = stream_ioc_objects(qs)
+        self.assertIsInstance(result, types.GeneratorType)
+
+    def test_stream_ioc_objects_yields_correct_fields(self):
+        qs = self.get_test_queryset()
+        iocs = list(stream_ioc_objects(qs))
+        self.assertGreater(len(iocs), 0)
+        for ioc in iocs:
+            self.assertIsInstance(ioc, dict)
+            self.assertIn("value", ioc)
+            self.assertIn("first_seen", ioc)
+            self.assertIn("feed_type", ioc)
+            self.assertIn("tags", ioc)
+
+    def test_build_ioc_json_list_returns_list(self):
+        qs = self.get_test_queryset()
+        result = build_ioc_json_list(qs)
+        self.assertIsInstance(result, list)
+        self.assertGreater(len(result), 0)
+        self.assertIsInstance(result[0], dict)
+        self.assertIn("value", result[0])
+
+    def test_stream_ioc_objects_correct_values(self):
+        qs = self.get_test_queryset()
+        values = [ioc["value"] for ioc in stream_ioc_objects(qs)]
+        self.assertIn(self.ioc.name, values)
+
+    def test_stream_ioc_objects_empty_queryset(self):
+        qs = self.get_test_queryset().none()
+        self.assertEqual(list(stream_ioc_objects(qs)), [])
+
+    def test_build_ioc_json_list_empty_queryset(self):
+        qs = self.get_test_queryset().none()
+        self.assertEqual(build_ioc_json_list(qs), [])
+
+    def test_stream_and_list_return_identical_data(self):
+        qs = self.get_test_queryset()
+        self.assertEqual(list(stream_ioc_objects(qs)), build_ioc_json_list(qs))
+
+    def test_verbose_fields_parity(self):
+        qs = self.get_test_queryset()
+        stream_result = list(stream_ioc_objects(qs, verbose=True))
+        list_result = build_ioc_json_list(qs, verbose=True)
+        self.assertEqual(stream_result, list_result)
+        for ioc in stream_result:
+            self.assertIn("days_seen", ioc)
+            self.assertIn("firehol_categories", ioc)
+
+    def test_include_sensors_parity(self):
+        qs = self.get_test_queryset()
+        stream_result = list(stream_ioc_objects(qs, include_sensors=True))
+        list_result = build_ioc_json_list(qs, include_sensors=True)
+        self.assertEqual(stream_result, list_result)
+
+    def test_list_input_support(self):
+        ioc_list = list(IOC.objects.filter(honeypots__active=True))
+        stream_result = list(stream_ioc_objects(ioc_list))
+        list_result = build_ioc_json_list(ioc_list)
+        self.assertEqual(stream_result, list_result)
+        self.assertGreater(len(stream_result), 0)
+        for ioc in stream_result:
+            self.assertIsInstance(ioc, dict)


### PR DESCRIPTION
**Description:**

Extracted `stream_ioc_objects()` as a generator function from `build_ioc_json_list()`. The NDJSON streaming path now calls `stream_ioc_objects()` directly instead of going through `build_feed_dict`, which was loading the entire IOC dataset into memory before yielding anything defeating the purpose of streaming.

`build_ioc_json_list` now just wraps `stream_ioc_objects` in `list()` so all existing callers get identical behavior as before.

**Related issues:** Closes #1443 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes 
# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.

