### PR TITLE
feat: Link HoneypotPayload to Cowrie sessions and attacker IOCs by SHA256. Closes #1509

### DIFF
--- a/api/serializers/payloads.py
+++ b/api/serializers/payloads.py
@@ -12,6 +12,13 @@ class HoneypotPayloadSerializer(serializers.ModelSerializer):
         slug_field="name",
         help_text="Names of the honeypots that captured this payload.",
     )
+    iocs = serializers.SlugRelatedField(
+        many=True,
+        read_only=True,
+        slug_field="name",
+        help_text="Attacker IPs (or other IOCs) linked to this payload.",
+    )
+    cowrie_sessions = serializers.SerializerMethodField(help_text="IDs of the Cowrie sessions that transferred this payload, as hex strings.")
 
     class Meta:
         model = HoneypotPayload
@@ -23,6 +30,8 @@ class HoneypotPayloadSerializer(serializers.ModelSerializer):
             "mime_type",
             "size",
             "source_honeypots",
+            "iocs",
+            "cowrie_sessions",
         ]
         extra_kwargs = {
             "id": {"help_text": "Unique identifier of the payload."},
@@ -32,3 +41,6 @@ class HoneypotPayloadSerializer(serializers.ModelSerializer):
             "mime_type": {"help_text": "MIME type of the payload file."},
             "size": {"help_text": "Size of the payload in bytes."},
         }
+
+    def get_cowrie_sessions(self, obj: HoneypotPayload) -> list[str]:
+        return [f"{session.session_id:x}" for session in obj.cowrie_sessions.all()]

--- a/api/views/payloads.py
+++ b/api/views/payloads.py
@@ -49,7 +49,7 @@ class HoneypotPayloadViewSet(viewsets.ReadOnlyModelViewSet):
     :class:`~api.permissions.IsThreatResearcherOrAdmin`.
     """
 
-    queryset = HoneypotPayload.objects.prefetch_related("source_honeypots").order_by("-id")
+    queryset = HoneypotPayload.objects.prefetch_related("source_honeypots", "iocs", "cowrie_sessions").order_by("-id")
     serializer_class = HoneypotPayloadSerializer
     permission_classes = [IsAuthenticated]
     lookup_field = "sha256"

--- a/greedybear/cronjobs/extraction/strategies/cowrie.py
+++ b/greedybear/cronjobs/extraction/strategies/cowrie.py
@@ -15,6 +15,7 @@ from greedybear.cronjobs.extraction.utils import (
 from greedybear.cronjobs.repositories import (
     CowrieSessionRepository,
     IocRepository,
+    PayloadRepository,
     SensorRepository,
 )
 from greedybear.models import IOC, CommandSequence, CowrieSession
@@ -60,8 +61,9 @@ class CowrieExtractionStrategy(BaseExtractionStrategy):
 
     Extracts scanner IPs, payload URLs from login attempts and file
     downloads, and session data including credentials and command
-    sequences. Links related IOCs (scanners to download URLs) and
-    deduplicates command sequences by hash.
+    sequences. Links related IOCs (scanners to download URLs), links file
+    transfers to any already-downloaded HoneypotPayload, and deduplicates
+    command sequences by hash.
     """
 
     def __init__(
@@ -70,9 +72,11 @@ class CowrieExtractionStrategy(BaseExtractionStrategy):
         ioc_repo: IocRepository,
         sensor_repo: SensorRepository,
         session_repo: CowrieSessionRepository = None,
+        payload_repo: PayloadRepository = None,
     ):
         super().__init__(honeypot, ioc_repo, sensor_repo)
         self.session_repo = session_repo or CowrieSessionRepository()
+        self.payload_repo = payload_repo or PayloadRepository()
         self.payloads_in_message = 0
         self.added_url_downloads = 0
 
@@ -274,6 +278,9 @@ class CowrieExtractionStrategy(BaseExtractionStrategy):
                         outfile=outfile,
                         timestamp=timestamp,
                     )
+
+                    if self.payload_repo.link_payload_to_session(session_record, shasum):
+                        self.log.info(f"linked existing payload {shasum[:8]}... to session {session_record.session_id:x}")
 
         session_record.interaction_count += 1
 

--- a/greedybear/cronjobs/payload_extraction.py
+++ b/greedybear/cronjobs/payload_extraction.py
@@ -11,6 +11,7 @@ from django.db.models.functions import Lower
 
 from greedybear.cronjobs.base import Cronjob
 from greedybear.cronjobs.http_client import HttpClient
+from greedybear.cronjobs.repositories import PayloadRepository
 from greedybear.models import HoneypotPayload
 
 
@@ -26,12 +27,18 @@ class PayloadExtractionJob(Cronjob):
     3. Checks quarantine disk usage against MAX_QUARANTINE_SIZE_GB before downloading.
     4. Downloads new payload files via ``/api/v1/payloads/download/{locator}``
        and saves them via QuarantineStorage.
+    5. Links each downloaded payload to any Cowrie sessions that already
+       transferred a file with the same SHA256.
     """
 
     # Timeout for the metadata listing request (seconds).
     METADATA_TIMEOUT = 30
     # Timeout for individual file download requests (seconds).
     DOWNLOAD_TIMEOUT = 120
+
+    def __init__(self, payload_repo: PayloadRepository = None):
+        super().__init__()
+        self.payload_repo = payload_repo if payload_repo is not None else PayloadRepository()
 
     def run(self) -> None:
         server_url = settings.TPOT_PAYLOAD_SERVER_URL
@@ -161,7 +168,8 @@ class PayloadExtractionJob(Cronjob):
 
     def _download_and_store(self, client: HttpClient, server_url: str, payload_meta: dict) -> bool:
         """
-        Download a single payload file and create its database record.
+        Download a single payload file, create its database record, and link
+        it to any Cowrie sessions that already transferred the same file.
 
         Args:
             client: HttpClient instance.
@@ -208,4 +216,8 @@ class PayloadExtractionJob(Cronjob):
         payload_obj.save()
 
         self.log.info(f"Stored new payload {sha256[:12]}… ({len(file_content)} bytes).")
+
+        linked = self.payload_repo.link_sessions_to_payload(payload_obj)
+        if linked:
+            self.log.info(f"Linked payload {sha256[:12]}… to {linked} cowrie session(s).")
         return True

--- a/greedybear/cronjobs/repositories/__init__.py
+++ b/greedybear/cronjobs/repositories/__init__.py
@@ -6,6 +6,7 @@ from greedybear.cronjobs.repositories.event import *
 from greedybear.cronjobs.repositories.firehol import *
 from greedybear.cronjobs.repositories.ioc import *
 from greedybear.cronjobs.repositories.mass_scanner import *
+from greedybear.cronjobs.repositories.payload import *
 from greedybear.cronjobs.repositories.sensor import *
 from greedybear.cronjobs.repositories.statistics import *
 from greedybear.cronjobs.repositories.tag import *

--- a/greedybear/cronjobs/repositories/payload.py
+++ b/greedybear/cronjobs/repositories/payload.py
@@ -1,5 +1,7 @@
 import logging
 
+from django.db.models.functions import Lower
+
 from greedybear.models import CowrieSession, HoneypotPayload
 
 
@@ -29,7 +31,9 @@ class PayloadRepository:
         Returns:
             Number of sessions linked.
         """
-        sessions = CowrieSession.objects.filter(file_transfers__shasum__iexact=payload.sha256).select_related("source").distinct()
+        # assumption: Cowrie always emits lowercase hex for shasum (hashlib.hexdigest()), and payload.sha256 is
+        # always stored in lowercase too, hence this plain comparison works with CowrieFileTransfer's shasum index.
+        sessions = CowrieSession.objects.filter(file_transfers__shasum=payload.sha256.lower()).select_related("source")
         linked = 0
         for session in sessions:
             payload.cowrie_sessions.add(session)
@@ -49,7 +53,7 @@ class PayloadRepository:
         Returns:
             True if a matching payload was found and linked.
         """
-        payload = HoneypotPayload.objects.filter(sha256__iexact=shasum).first()
+        payload = HoneypotPayload.objects.annotate(sha256_lower=Lower("sha256")).filter(sha256_lower=shasum.lower()).first()
         if payload is None:
             return False
         payload.cowrie_sessions.add(session)

--- a/greedybear/cronjobs/repositories/payload.py
+++ b/greedybear/cronjobs/repositories/payload.py
@@ -1,0 +1,57 @@
+import logging
+
+from greedybear.models import CowrieSession, HoneypotPayload
+
+
+class PayloadRepository:
+    """
+    Repository joining HoneypotPayload records with the CowrieSession(s) that
+    transferred the same file, matched by SHA256 hash.
+
+    ExtractionJob (Cowrie) and PayloadExtractionJob run independently and can
+    complete in either order within the same tick, so this repository is used
+    from both directions: once a payload is downloaded, and once a Cowrie file
+    transfer is recorded, each side looks for a match already stored by the
+    other.
+    """
+
+    def __init__(self):
+        self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+    def link_sessions_to_payload(self, payload: HoneypotPayload) -> int:
+        """
+        Find Cowrie sessions that transferred a file matching this payload's
+        SHA256, and link them (and their source IOCs) to the payload.
+
+        Args:
+            payload: HoneypotPayload instance to link, already saved.
+
+        Returns:
+            Number of sessions linked.
+        """
+        sessions = CowrieSession.objects.filter(file_transfers__shasum__iexact=payload.sha256).select_related("source").distinct()
+        linked = 0
+        for session in sessions:
+            payload.cowrie_sessions.add(session)
+            payload.iocs.add(session.source)
+            linked += 1
+        return linked
+
+    def link_payload_to_session(self, session: CowrieSession, shasum: str) -> bool:
+        """
+        Find a HoneypotPayload matching this file transfer's SHA256, and link
+        it (and the session's source IOC) to the session.
+
+        Args:
+            session: CowrieSession instance that transferred the file.
+            shasum: SHA256 checksum of the transferred file.
+
+        Returns:
+            True if a matching payload was found and linked.
+        """
+        payload = HoneypotPayload.objects.filter(sha256__iexact=shasum).first()
+        if payload is None:
+            return False
+        payload.cowrie_sessions.add(session)
+        payload.iocs.add(session.source)
+        return True

--- a/tests/test_cowrie_extraction.py
+++ b/tests/test_cowrie_extraction.py
@@ -13,7 +13,7 @@ from greedybear.cronjobs.extraction.strategies.cowrie import (
     normalize_credential_field,
     parse_url_hostname,
 )
-from greedybear.models import CommandSequence
+from greedybear.models import CommandSequence, HoneypotPayload
 from tests import ExtractionTestCase
 
 
@@ -100,12 +100,15 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
         self.mock_ioc_repo = Mock()
         self.mock_sensor_repo = Mock()
         self.mock_session_repo = Mock()
+        self.mock_payload_repo = Mock()
+        self.mock_payload_repo.link_payload_to_session.return_value = False
 
         self.strategy = CowrieExtractionStrategy(
             "Cowrie",
             self.mock_ioc_repo,
             self.mock_sensor_repo,
             self.mock_session_repo,
+            self.mock_payload_repo,
         )
         self.strategy.ioc_processor = Mock()
 
@@ -323,7 +326,32 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
             outfile="/data/cowrie/downloads/bad.exe",
             timestamp=datetime(2023, 1, 1, 10, 0, 4),
         )
+        self.mock_payload_repo.link_payload_to_session.assert_called_once_with(session_record, "abc123def456")
         self.assertEqual(session_record.interaction_count, 1)
+
+    def test_process_session_hit_file_download_links_real_payload(self):
+        """Test that the strategy's real PayloadRepository links a matching payload."""
+        strategy = CowrieExtractionStrategy(
+            "Cowrie",
+            self.mock_ioc_repo,
+            self.mock_sensor_repo,
+            self.mock_session_repo,
+        )
+        payload = HoneypotPayload.objects.create(sha256="abc123def456")
+
+        hit = {
+            "eventid": "cowrie.session.file_download",
+            "timestamp": "2023-01-01T10:00:04",
+            "shasum": "abc123def456",
+            "url": "http://malware.com/bad.exe",
+            "outfile": "/data/cowrie/downloads/bad.exe",
+        }
+        ioc = Mock(name="1.2.3.4")
+
+        strategy._process_session_hit(self.cowrie_session, hit, ioc)
+
+        self.assertIn(self.cowrie_session, payload.cowrie_sessions.all())
+        self.assertIn(self.cowrie_session.source, payload.iocs.all())
 
     def test_process_session_hit_file_upload_creates_transfer(self):
         """Test processing of file upload event creates file transfer."""
@@ -348,6 +376,7 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
             outfile="/var/lib/cowrie/downloads/deadbeef123456",
             timestamp=datetime(2023, 1, 1, 10, 0, 4),
         )
+        self.mock_payload_repo.link_payload_to_session.assert_called_once_with(session_record, "deadbeef123456")
         self.assertEqual(session_record.interaction_count, 1)
 
     def test_process_session_hit_file_upload_without_shasum(self):
@@ -367,6 +396,7 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
         self.strategy._process_session_hit(session_record, hit, ioc)
 
         self.mock_session_repo.get_or_create_file_transfer.assert_not_called()
+        self.mock_payload_repo.link_payload_to_session.assert_not_called()
         self.assertEqual(session_record.interaction_count, 1)
 
     def test_add_fks_both_exist(self):

--- a/tests/test_payload_extraction.py
+++ b/tests/test_payload_extraction.py
@@ -2,9 +2,10 @@ from unittest.mock import MagicMock, Mock, patch
 
 import requests
 from django.test import override_settings
+from django.utils import timezone
 
 from greedybear.cronjobs.payload_extraction import PayloadExtractionJob
-from greedybear.models import HoneypotPayload
+from greedybear.models import CowrieFileTransfer, HoneypotPayload
 
 from . import CustomTestCase
 
@@ -93,6 +94,68 @@ class TestPayloadExtractionJob(CustomTestCase):
         # Verify download hit the /download/ endpoint.
         download_call = mock_client.get.call_args_list[1]
         self.assertIn("/api/v1/payloads/download/cowrie/aaa", download_call[0][0])
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="test-key",
+        MAX_QUARANTINE_SIZE_GB=5,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_download_without_matching_session(self, mock_http_class, mock_usage):
+        """Job should not link a downloaded payload to any session when no matching transfer exists."""
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [{"sha256": "a" * 64, "locator": "cowrie/aaa"}]
+        mock_download_resp = Mock()
+        mock_download_resp.content = b"\x00" * 256
+        mock_client.get.side_effect = [mock_metadata_resp, mock_download_resp]
+        mock_usage.return_value = 0
+
+        self.job.run()
+
+        # No CowrieFileTransfer was ever created for this hash, so nothing should link.
+        obj = HoneypotPayload.objects.get(sha256="a" * 64)
+        self.assertEqual(obj.cowrie_sessions.count(), 0)
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="test-key",
+        MAX_QUARANTINE_SIZE_GB=5,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_download_links_cowrie_session(self, mock_http_class, mock_usage):
+        """Job should link a downloaded payload to a Cowrie session that already transferred the same file."""
+        # Same hash as the payload metadata below - simulates Cowrie's extraction already
+        # having recorded this transfer before the payload download runs.
+        CowrieFileTransfer.objects.create(
+            session=self.cowrie_session,
+            shasum="a" * 64,
+            url="",
+            outfile="",
+            timestamp=timezone.now(),
+        )
+
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [{"sha256": "a" * 64, "locator": "cowrie/aaa"}]
+        mock_download_resp = Mock()
+        mock_download_resp.content = b"\x00" * 256
+        mock_client.get.side_effect = [mock_metadata_resp, mock_download_resp]
+        mock_usage.return_value = 0
+
+        self.job.run()
+
+        obj = HoneypotPayload.objects.get(sha256="a" * 64)
+        self.assertIn(self.cowrie_session, obj.cowrie_sessions.all())
+        self.assertIn(self.cowrie_session.source, obj.iocs.all())
 
     @override_settings(
         TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",

--- a/tests/test_payload_repository.py
+++ b/tests/test_payload_repository.py
@@ -37,15 +37,6 @@ class TestPayloadRepository(CustomTestCase):
         self.assertIn(self.cowrie_session, payload.cowrie_sessions.all())
         self.assertIn(self.cowrie_session.source, payload.iocs.all())
 
-    def test_link_sessions_to_payload_case_insensitive_match(self):
-        self._make_transfer(self.cowrie_session, ("AB" * 32).upper())
-        payload = HoneypotPayload.objects.create(sha256=("ab" * 32).lower())
-
-        linked = self.repo.link_sessions_to_payload(payload)
-
-        self.assertEqual(linked, 1)
-        self.assertIn(self.cowrie_session, payload.cowrie_sessions.all())
-
     def test_link_sessions_to_payload_multiple_sessions(self):
         self._make_transfer(self.cowrie_session, "c" * 64)
         self._make_transfer(self.cowrie_session_2, "c" * 64)
@@ -56,17 +47,6 @@ class TestPayloadRepository(CustomTestCase):
         self.assertEqual(linked, 2)
         self.assertIn(self.cowrie_session, payload.cowrie_sessions.all())
         self.assertIn(self.cowrie_session_2, payload.cowrie_sessions.all())
-
-    def test_link_sessions_to_payload_does_not_overcount_case_variant_duplicates(self):
-        """A same-session, differently-cased shasum pair must still count as one linked session."""
-        self._make_transfer(self.cowrie_session, "d" * 64)
-        self._make_transfer(self.cowrie_session, "D" * 64)
-        payload = HoneypotPayload.objects.create(sha256="d" * 64)
-
-        linked = self.repo.link_sessions_to_payload(payload)
-
-        self.assertEqual(linked, 1)
-        self.assertEqual(payload.cowrie_sessions.count(), 1)
 
     def test_link_payload_to_session_no_match(self):
         linked = self.repo.link_payload_to_session(self.cowrie_session, "e" * 64)

--- a/tests/test_payload_repository.py
+++ b/tests/test_payload_repository.py
@@ -1,0 +1,110 @@
+from django.utils import timezone
+
+from greedybear.cronjobs.repositories import PayloadRepository
+from greedybear.models import IOC, CowrieFileTransfer, CowrieSession, HoneypotPayload
+
+from . import CustomTestCase
+
+
+class TestPayloadRepository(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self.repo = PayloadRepository()
+
+    def _make_transfer(self, session, shasum):
+        return CowrieFileTransfer.objects.create(
+            session=session,
+            shasum=shasum,
+            url="",
+            outfile="",
+            timestamp=timezone.now(),
+        )
+
+    def test_link_sessions_to_payload_no_match(self):
+        payload = HoneypotPayload.objects.create(sha256="a" * 64)
+        linked = self.repo.link_sessions_to_payload(payload)
+        self.assertEqual(linked, 0)
+        self.assertEqual(payload.cowrie_sessions.count(), 0)
+        self.assertEqual(payload.iocs.count(), 0)
+
+    def test_link_sessions_to_payload_single_match(self):
+        self._make_transfer(self.cowrie_session, "a" * 64)
+        payload = HoneypotPayload.objects.create(sha256="a" * 64)
+
+        linked = self.repo.link_sessions_to_payload(payload)
+
+        self.assertEqual(linked, 1)
+        self.assertIn(self.cowrie_session, payload.cowrie_sessions.all())
+        self.assertIn(self.cowrie_session.source, payload.iocs.all())
+
+    def test_link_sessions_to_payload_case_insensitive_match(self):
+        self._make_transfer(self.cowrie_session, ("AB" * 32).upper())
+        payload = HoneypotPayload.objects.create(sha256=("ab" * 32).lower())
+
+        linked = self.repo.link_sessions_to_payload(payload)
+
+        self.assertEqual(linked, 1)
+        self.assertIn(self.cowrie_session, payload.cowrie_sessions.all())
+
+    def test_link_sessions_to_payload_multiple_sessions(self):
+        self._make_transfer(self.cowrie_session, "c" * 64)
+        self._make_transfer(self.cowrie_session_2, "c" * 64)
+        payload = HoneypotPayload.objects.create(sha256="c" * 64)
+
+        linked = self.repo.link_sessions_to_payload(payload)
+
+        self.assertEqual(linked, 2)
+        self.assertIn(self.cowrie_session, payload.cowrie_sessions.all())
+        self.assertIn(self.cowrie_session_2, payload.cowrie_sessions.all())
+
+    def test_link_sessions_to_payload_does_not_overcount_case_variant_duplicates(self):
+        """A same-session, differently-cased shasum pair must still count as one linked session."""
+        self._make_transfer(self.cowrie_session, "d" * 64)
+        self._make_transfer(self.cowrie_session, "D" * 64)
+        payload = HoneypotPayload.objects.create(sha256="d" * 64)
+
+        linked = self.repo.link_sessions_to_payload(payload)
+
+        self.assertEqual(linked, 1)
+        self.assertEqual(payload.cowrie_sessions.count(), 1)
+
+    def test_link_payload_to_session_no_match(self):
+        linked = self.repo.link_payload_to_session(self.cowrie_session, "e" * 64)
+        self.assertFalse(linked)
+
+    def test_link_payload_to_session_match(self):
+        payload = HoneypotPayload.objects.create(sha256="f" * 64)
+
+        linked = self.repo.link_payload_to_session(self.cowrie_session, "f" * 64)
+
+        self.assertTrue(linked)
+        self.assertIn(self.cowrie_session, payload.cowrie_sessions.all())
+        self.assertIn(self.cowrie_session.source, payload.iocs.all())
+
+    def test_link_payload_to_session_case_insensitive_match(self):
+        payload = HoneypotPayload.objects.create(sha256=("11" * 32).lower())
+
+        linked = self.repo.link_payload_to_session(self.cowrie_session, ("11" * 32).upper())
+
+        self.assertTrue(linked)
+        self.assertIn(self.cowrie_session, payload.cowrie_sessions.all())
+
+    def test_link_payload_to_session_idempotent(self):
+        payload = HoneypotPayload.objects.create(sha256="9" * 64)
+
+        self.repo.link_payload_to_session(self.cowrie_session, "9" * 64)
+        self.repo.link_payload_to_session(self.cowrie_session, "9" * 64)
+
+        self.assertEqual(payload.cowrie_sessions.count(), 1)
+        self.assertEqual(payload.iocs.count(), 1)
+
+    def test_link_sessions_to_payload_only_matches_exact_hash(self):
+        other_ioc = IOC.objects.create(name="203.0.113.9", type="ip")
+        other_session = CowrieSession.objects.create(session_id=0x7777, source=other_ioc)
+        self._make_transfer(other_session, "b" * 64)
+        payload = HoneypotPayload.objects.create(sha256="a" * 64)
+
+        linked = self.repo.link_sessions_to_payload(payload)
+
+        self.assertEqual(linked, 0)
+        self.assertNotIn(other_session, payload.cowrie_sessions.all())

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -6,6 +6,7 @@ from rest_framework.serializers import ValidationError
 
 from api.serializers import (
     AdvancedFeedRequestSerializer,
+    HoneypotPayloadSerializer,
     IOCSerializer,
     SimpleFeedResponseSerializer,
     TrendingFeedRequestSerializer,
@@ -13,7 +14,7 @@ from api.serializers import (
 )
 from greedybear.consts import PAYLOAD_REQUEST, SCANNER
 from greedybear.enums import IpReputation
-from greedybear.models import IOC, Honeypot, Sensor
+from greedybear.models import IOC, Honeypot, HoneypotPayload, Sensor
 from tests import CustomTestCase
 
 
@@ -366,3 +367,37 @@ class IOCSerializerTestCase(CustomTestCase):
         self.assertEqual(sensors_data[0]["label"], "home-pi")
         self.assertEqual(sensors_data[1]["address"], "10.0.0.2")
         self.assertEqual(sensors_data[1]["label"], "")
+
+
+class HoneypotPayloadSerializerTestCase(CustomTestCase):
+    def test_empty_relations_serialize_as_empty_lists(self):
+        payload = HoneypotPayload.objects.create(sha256="a" * 64)
+
+        serializer = HoneypotPayloadSerializer(payload)
+        data = serializer.data
+
+        self.assertEqual(data["iocs"], [])
+        self.assertEqual(data["cowrie_sessions"], [])
+
+    def test_serializes_iocs_as_names(self):
+        payload = HoneypotPayload.objects.create(sha256="b" * 64)
+        payload.iocs.add(self.ioc, self.ioc_2)
+
+        serializer = HoneypotPayloadSerializer(payload)
+        data = serializer.data
+
+        self.assertEqual(sorted(data["iocs"]), sorted([self.ioc.name, self.ioc_2.name]))
+        self.assertEqual(data["cowrie_sessions"], [])
+
+    def test_serializes_cowrie_sessions_as_hex_ids(self):
+        payload = HoneypotPayload.objects.create(sha256="c" * 64)
+        payload.cowrie_sessions.add(self.cowrie_session, self.cowrie_session_2)
+
+        serializer = HoneypotPayloadSerializer(payload)
+        data = serializer.data
+
+        self.assertEqual(
+            sorted(data["cowrie_sessions"]),
+            sorted([f"{self.cowrie_session.session_id:x}", f"{self.cowrie_session_2.session_id:x}"]),
+        )
+        self.assertEqual(data["iocs"], [])


### PR DESCRIPTION
# Description

Adds the join GreedyBear was missing between downloaded payloads and the Cowrie sessions/attacker IOCs that delivered them. `HoneypotPayload.cowrie_sessions`/`.iocs` existed but were not being populated. This join occurs bi-directionally, in both `PayloadExtractionJob._download_and_store` and `CowrieExtractionStrategy._process_session_hit`, so it works regardless of whether the session or the payload shows up first in a given extraction window.

**_IMPORTANT NOTE_**: This adds one change beyond the strict scope of issue #1509. It exposes both fields on the payloads API (`iocs`, `cowrie_sessions`). I have added it since populated fields that are not returned in the corresponding APIs for the appropriate users would be incomplete development on this feature. Please refer to the Wiki Update section.

### Related issues

Closes #1509

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### Wiki update

The Payloads API response gains two new fields, not yet reflected in the Usage page:

`iocs` (list[str]): Attacker IPs (or other IOCs) linked to this payload.
`cowrie_sessions` (list[str]): IDs of the Cowrie sessions that transferred this payload, as hex strings.