### PR TITLE
Add API docs links to the header Docs menu. Closes #1541

### DIFF
--- a/frontend/src/constants/environment.js
+++ b/frontend/src/constants/environment.js
@@ -1,5 +1,7 @@
 export const GREEDYBEAR_DOCS_URL =
   "https://github.com/GreedyBear-Project/GreedyBear/wiki";
+export const GREEDYBEAR_API_SWAGGER_URL = "/api/schema/swagger-ui/";
+export const GREEDYBEAR_API_REDOC_URL = "/api/schema/redoc/";
 
 // env variables
 // Vite uses import.meta.env, Jest uses process.env

--- a/frontend/src/layouts/AppHeader.jsx
+++ b/frontend/src/layouts/AppHeader.jsx
@@ -6,6 +6,10 @@ import {
   Collapse,
   NavbarBrand,
   NavbarToggler,
+  UncontrolledDropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem,
 } from "reactstrap";
 import { NavLink as RRNavLink } from "react-router-dom";
 import {
@@ -13,14 +17,20 @@ import {
   MdOutlineFeed,
   MdDashboard,
   MdTrendingUp,
+  MdDescription,
 } from "react-icons/md";
 import { RiBookReadFill } from "react-icons/ri";
+import { SiGithub, SiSwagger } from "react-icons/si";
 
 // lib
 import { NavLink } from "@greedybear/gb-ui";
 
 // constants
-import { GREEDYBEAR_DOCS_URL } from "../constants/environment";
+import {
+  GREEDYBEAR_DOCS_URL,
+  GREEDYBEAR_API_SWAGGER_URL,
+  GREEDYBEAR_API_REDOC_URL,
+} from "../constants/environment";
 
 // local
 import UserMenu from "./widget/UserMenu";
@@ -49,17 +59,42 @@ const guestLinks = (
 );
 
 const rightLinks = (
-  <NavItem>
-    <a
-      className="d-flex-start-center btn text-gray"
-      href={GREEDYBEAR_DOCS_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+  <UncontrolledDropdown nav inNavbar>
+    <DropdownToggle nav className="d-flex-start-center text-gray">
       <RiBookReadFill />
       <span className="ms-1">Docs</span>
-    </a>
-  </NavItem>
+    </DropdownToggle>
+    <DropdownMenu end className="bg-dark" data-bs-popper>
+      <DropdownItem
+        tag="a"
+        href={GREEDYBEAR_DOCS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <SiGithub className="me-2" />
+        Wiki
+      </DropdownItem>
+      <DropdownItem divider />
+      <DropdownItem
+        tag="a"
+        href={GREEDYBEAR_API_SWAGGER_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <SiSwagger className="me-2" />
+        Swagger UI
+      </DropdownItem>
+      <DropdownItem
+        tag="a"
+        href={GREEDYBEAR_API_REDOC_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <MdDescription className="me-2" />
+        Redoc
+      </DropdownItem>
+    </DropdownMenu>
+  </UncontrolledDropdown>
 );
 
 function AppHeader() {

--- a/frontend/tests/layouts/AppHeader.test.jsx
+++ b/frontend/tests/layouts/AppHeader.test.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+import AppHeader from "../../src/layouts/AppHeader";
+import { AUTHENTICATION_STATUSES } from "../../src/constants";
+import {
+  GREEDYBEAR_DOCS_URL,
+  GREEDYBEAR_API_SWAGGER_URL,
+  GREEDYBEAR_API_REDOC_URL,
+} from "../../src/constants/environment";
+
+// Mock useAuthStore so the header renders the guest links
+// and never reaches into the real (persisted) store.
+const mockUseAuthStore = vi.fn();
+vi.mock("../../src/stores", () => ({
+  useAuthStore: (selector) => mockUseAuthStore(selector),
+}));
+
+const renderHeader = () =>
+  render(
+    <MemoryRouter>
+      <AppHeader />
+    </MemoryRouter>,
+  );
+
+// The dropdown items are only exposed to the accessibility tree
+// once the menu is open, so every link assertion opens it first.
+const openDocsMenu = async () => {
+  renderHeader();
+  await userEvent.click(screen.getByText("Docs"));
+};
+
+describe("AppHeader docs menu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuthStore.mockImplementation((selector) =>
+      selector({ isAuthenticated: AUTHENTICATION_STATUSES.FALSE }),
+    );
+  });
+
+  test("renders the Docs dropdown toggle", () => {
+    renderHeader();
+    expect(screen.getByText("Docs")).toBeInTheDocument();
+  });
+
+  test("links to the wiki and both API doc UIs", async () => {
+    await openDocsMenu();
+
+    const expectedLinks = [
+      ["Wiki", GREEDYBEAR_DOCS_URL],
+      ["Swagger UI", GREEDYBEAR_API_SWAGGER_URL],
+      ["Redoc", GREEDYBEAR_API_REDOC_URL],
+    ];
+
+    expectedLinks.forEach(([label, href]) => {
+      const link = screen.getByRole("menuitem", { name: label });
+      expect(link).toHaveAttribute("href", href);
+    });
+  });
+
+  test("opens every docs link in a new tab safely", async () => {
+    await openDocsMenu();
+
+    ["Wiki", "Swagger UI", "Redoc"].forEach((label) => {
+      const link = screen.getByRole("menuitem", { name: label });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  });
+});


### PR DESCRIPTION
# Description

The API docs generated by drf-spectacular were served but not linked anywhere in the UI. This turns the existing "Docs" button in the header into a dropdown with the Wiki plus both API doc UIs (Swagger and Redoc)

I left out the raw `/api/schema/` link because it downloads a YAML file instead of opening a page, which felt out of place in a nav menu.

### Related issues

Closes #1541 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

- [x] I have provided a screenshot of the result in the PR.
- [x] I have created new frontend tests for the new component or updated existing ones.

Docs dropdown, open:

<img width="1280" height="713" alt="greedybear-1541-docs-dropdown" src="https://github.com/user-attachments/assets/c503b5c8-f3c9-46da-8c30-caeca61c33e6" />

Note: this PR only touches frontend files, so Ruff has nothing to check. ESLint and Prettier both pass, and the full vitest suite is green. `frontend/tests/layouts/` is a new folder, there were no tests for any layout component before this.

