### PR TITLE
Log payload quota exhaustion as error

### DIFF
--- a/greedybear/cronjobs/payload_extraction.py
+++ b/greedybear/cronjobs/payload_extraction.py
@@ -61,7 +61,7 @@ class PayloadExtractionJob(Cronjob):
             for payload_meta in new_payloads:
                 # Check disk usage before each download.
                 if self._quarantine_usage_bytes() >= max_size_bytes:
-                    self.log.warning(f"Quarantine directory has reached the {settings.MAX_QUARANTINE_SIZE_GB} GB limit. Stopping downloads.")
+                    self.log.error(f"Quarantine directory has reached the {settings.MAX_QUARANTINE_SIZE_GB} GB limit. Stopping downloads.")
                     break
 
                 if self._download_and_store(client, server_url, payload_meta):

--- a/tests/test_payload_extraction.py
+++ b/tests/test_payload_extraction.py
@@ -146,8 +146,12 @@ class TestPayloadExtractionJob(CustomTestCase):
         # Report disk usage above the limit (0.001 GB ~ 1,073,741 bytes).
         mock_usage.return_value = 2_000_000
 
-        self.job.run()
+        with patch.object(self.job.log, "error") as mock_error:
+            self.job.run()
 
+        mock_error.assert_called_once_with(
+            "Quarantine directory has reached the 0.001 GB limit. Stopping downloads."
+        )
         # No payload should have been downloaded.
         self.assertEqual(HoneypotPayload.objects.count(), 0)
 


### PR DESCRIPTION
Closes #1555.

Changes the quarantine quota log from warning to error so it reaches the existing error-log monitoring path used for Slack/ntfy notifications.

Also updates the existing quota test to assert that the condition is logged at error level.

Local full test execution was not completed because the project's psycopg C dependency requires PostgreSQL build tooling on Windows. CI is left to validate the change in the repository's supported environment.