### PR TITLE
Payload quota error notification. Closes #1555

### DIFF
--- a/greedybear/cronjobs/payload_extraction.py
+++ b/greedybear/cronjobs/payload_extraction.py
@@ -61,7 +61,7 @@ class PayloadExtractionJob(Cronjob):
             for payload_meta in new_payloads:
                 # Check disk usage before each download.
                 if self._quarantine_usage_bytes() >= max_size_bytes:
-                    self.log.warning(f"Quarantine directory has reached the {settings.MAX_QUARANTINE_SIZE_GB} GB limit. Stopping downloads.")
+                    self.log.error(f"Quarantine directory has reached the {settings.MAX_QUARANTINE_SIZE_GB} GB limit. Stopping downloads.")
                     break
 
                 if self._download_and_store(client, server_url, payload_meta):

--- a/tests/test_payload_extraction.py
+++ b/tests/test_payload_extraction.py
@@ -146,8 +146,10 @@ class TestPayloadExtractionJob(CustomTestCase):
         # Report disk usage above the limit (0.001 GB ~ 1,073,741 bytes).
         mock_usage.return_value = 2_000_000
 
-        self.job.run()
+        with patch.object(self.job.log, "error") as mock_error:
+            self.job.run()
 
+        mock_error.assert_called_once_with("Quarantine directory has reached the 0.001 GB limit. Stopping downloads.")
         # No payload should have been downloaded.
         self.assertEqual(HoneypotPayload.objects.count(), 0)
 


### PR DESCRIPTION
# Description

Changes the quarantine quota message from warning to error so it reaches the existing error-log monitoring path used for Slack/ntfy notifications.

The existing quota-limit test also verifies that the condition is logged at error level.

### Related issues

Closes #1555.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about how to Contribute to this project.
- [x] I chose an appropriate title for the pull request in the form: <feature name>. Closes #999
- [x] My branch is based on develop.
- [x] The pull request is for the branch develop.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the docs. No wiki update is required for this change.
- [x] Linter (Ruff) gave 0 errors.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

No GUI changes.

# Review process

Opening this as a draft while CI validates the change.