### PR TITLE
fix: normalize SHA256 case in payload extraction. Closes #1556

### DIFF
--- a/greedybear/cronjobs/payload_extraction.py
+++ b/greedybear/cronjobs/payload_extraction.py
@@ -7,10 +7,31 @@ from pathlib import Path
 import requests
 from django.conf import settings
 from django.core.files.base import ContentFile
+from django.db.models.functions import Lower
 
 from greedybear.cronjobs.base import Cronjob
 from greedybear.cronjobs.http_client import HttpClient
 from greedybear.models import HoneypotPayload
+
+
+def normalize_sha256(value: str) -> str:
+    """
+    Lower-case a SHA256 hash so it matches the way hashes are stored.
+
+    HoneypotPayload enforces uniqueness with UniqueConstraint(Lower("sha256")),
+    and the event-injection path already lower-cases before writing (see
+    greedybear/process_event.py::_process_payload_hashes). Normalizing the
+    payload-server path too keeps both writers consistent, so a hash that
+    differs only in case is recognised as a duplicate instead of reaching the
+    insert and violating the constraint.
+
+    Args:
+        value: SHA256 hash as received from the payload server.
+
+    Returns:
+        The hash in lower case.
+    """
+    return value.lower()
 
 
 class PayloadExtractionJob(Cronjob):
@@ -126,15 +147,24 @@ class PayloadExtractionJob(Cronjob):
         Returns:
             list[dict]: Only the unique payloads not yet stored locally.
         """
-        incoming_hashes = {p["sha256"] for p in payloads if "sha256" in p}
-        existing_hashes = set(HoneypotPayload.objects.filter(sha256__in=incoming_hashes).values_list("sha256", flat=True))
+        incoming_hashes = {normalize_sha256(p["sha256"]) for p in payloads if "sha256" in p}
+        # Compare case-insensitively on both sides: rows written before this
+        # normalization existed may still hold a mixed-case hash, and the unique
+        # constraint is on Lower("sha256"). A case-sensitive lookup would miss
+        # them, letting the insert through to fail on the constraint instead.
+        existing_hashes = set(
+            HoneypotPayload.objects.annotate(sha256_lower=Lower("sha256")).filter(sha256_lower__in=incoming_hashes).values_list("sha256_lower", flat=True)
+        )
         new_hashes = incoming_hashes - existing_hashes
         self.log.debug(f"Deduplication: {len(incoming_hashes)} incoming, {len(existing_hashes)} existing, {len(new_hashes)} new.")
         # Keep only the first occurrence of each sha256 to avoid IntegrityError.
+        # Hashes are compared normalized, so entries differing only in case
+        # collapse into one instead of colliding on the constraint.
         seen = set()
         unique = []
         for p in payloads:
-            sha = p.get("sha256")
+            raw_sha = p.get("sha256")
+            sha = normalize_sha256(raw_sha) if raw_sha else None
             if sha in new_hashes and sha not in seen:
                 seen.add(sha)
                 unique.append(p)
@@ -161,7 +191,9 @@ class PayloadExtractionJob(Cronjob):
         Returns:
             bool: True if download and storage succeeded, False otherwise.
         """
-        sha256 = payload_meta["sha256"]
+        # Normalized here as well as in _deduplicate, so the stored row and the
+        # quarantine filename always use the same case as every other writer.
+        sha256 = normalize_sha256(payload_meta["sha256"])
         locator = payload_meta.get("locator", "")
 
         if not locator:

--- a/greedybear/cronjobs/payload_extraction.py
+++ b/greedybear/cronjobs/payload_extraction.py
@@ -14,26 +14,6 @@ from greedybear.cronjobs.http_client import HttpClient
 from greedybear.models import HoneypotPayload
 
 
-def normalize_sha256(value: str) -> str:
-    """
-    Lower-case a SHA256 hash so it matches the way hashes are stored.
-
-    HoneypotPayload enforces uniqueness with UniqueConstraint(Lower("sha256")),
-    and the event-injection path already lower-cases before writing (see
-    greedybear/process_event.py::_process_payload_hashes). Normalizing the
-    payload-server path too keeps both writers consistent, so a hash that
-    differs only in case is recognised as a duplicate instead of reaching the
-    insert and violating the constraint.
-
-    Args:
-        value: SHA256 hash as received from the payload server.
-
-    Returns:
-        The hash in lower case.
-    """
-    return value.lower()
-
-
 class PayloadExtractionJob(Cronjob):
     """
     Fetch new payloads from the tpot-payload-server, deduplicate them
@@ -147,11 +127,11 @@ class PayloadExtractionJob(Cronjob):
         Returns:
             list[dict]: Only the unique payloads not yet stored locally.
         """
-        incoming_hashes = {normalize_sha256(p["sha256"]) for p in payloads if "sha256" in p}
-        # Compare case-insensitively on both sides: rows written before this
-        # normalization existed may still hold a mixed-case hash, and the unique
-        # constraint is on Lower("sha256"). A case-sensitive lookup would miss
-        # them, letting the insert through to fail on the constraint instead.
+        # HoneypotPayload is unique on Lower("sha256"), so compare case-insensitively
+        # on both sides. Rows written before this normalization existed may still hold
+        # a mixed-case hash; a case-sensitive lookup would miss them and let the insert
+        # through to fail on the constraint instead.
+        incoming_hashes = {p["sha256"].lower() for p in payloads if "sha256" in p}
         existing_hashes = set(
             HoneypotPayload.objects.annotate(sha256_lower=Lower("sha256")).filter(sha256_lower__in=incoming_hashes).values_list("sha256_lower", flat=True)
         )
@@ -164,7 +144,7 @@ class PayloadExtractionJob(Cronjob):
         unique = []
         for p in payloads:
             raw_sha = p.get("sha256")
-            sha = normalize_sha256(raw_sha) if raw_sha else None
+            sha = raw_sha.lower() if raw_sha else None
             if sha in new_hashes and sha not in seen:
                 seen.add(sha)
                 unique.append(p)
@@ -191,9 +171,9 @@ class PayloadExtractionJob(Cronjob):
         Returns:
             bool: True if download and storage succeeded, False otherwise.
         """
-        # Normalized here as well as in _deduplicate, so the stored row and the
-        # quarantine filename always use the same case as every other writer.
-        sha256 = normalize_sha256(payload_meta["sha256"])
+        # Lower-cased like in _deduplicate, so the stored row and the quarantine
+        # filename always use the same case as every other writer.
+        sha256 = payload_meta["sha256"].lower()
         locator = payload_meta.get("locator", "")
 
         if not locator:

--- a/tests/test_payload_extraction.py
+++ b/tests/test_payload_extraction.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 import requests
 from django.test import override_settings
 
-from greedybear.cronjobs.payload_extraction import PayloadExtractionJob, normalize_sha256
+from greedybear.cronjobs.payload_extraction import PayloadExtractionJob
 from greedybear.models import HoneypotPayload
 
 from . import CustomTestCase
@@ -334,12 +334,6 @@ class TestPayloadExtractionJob(CustomTestCase):
     # in case must be treated as a duplicate. Before the fix, the case-sensitive
     # lookup missed it, the insert went ahead and the unique constraint aborted
     # the whole run.
-
-    def test_normalize_sha256_lower_cases_the_hash(self):
-        """normalize_sha256 should lower-case whatever the server sent."""
-        self.assertEqual(normalize_sha256("A" * 64), "a" * 64)
-        self.assertEqual(normalize_sha256("a" * 64), "a" * 64)
-        self.assertEqual(normalize_sha256("AbCd" * 16), "abcd" * 16)
 
     @override_settings(
         TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",

--- a/tests/test_payload_extraction.py
+++ b/tests/test_payload_extraction.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 import requests
 from django.test import override_settings
 
-from greedybear.cronjobs.payload_extraction import PayloadExtractionJob
+from greedybear.cronjobs.payload_extraction import PayloadExtractionJob, normalize_sha256
 from greedybear.models import HoneypotPayload
 
 from . import CustomTestCase
@@ -328,6 +328,132 @@ class TestPayloadExtractionJob(CustomTestCase):
         """_quarantine_usage_bytes should return 0 if quarantine dir doesn't exist."""
         result = self.job._quarantine_usage_bytes()
         self.assertEqual(result, 0)
+
+    # SHA256 case normalization (see issue #1556).
+    # HoneypotPayload is unique on Lower("sha256"), so a hash that differs only
+    # in case must be treated as a duplicate. Before the fix, the case-sensitive
+    # lookup missed it, the insert went ahead and the unique constraint aborted
+    # the whole run.
+
+    def test_normalize_sha256_lower_cases_the_hash(self):
+        """normalize_sha256 should lower-case whatever the server sent."""
+        self.assertEqual(normalize_sha256("A" * 64), "a" * 64)
+        self.assertEqual(normalize_sha256("a" * 64), "a" * 64)
+        self.assertEqual(normalize_sha256("AbCd" * 16), "abcd" * 16)
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="",
+        MAX_QUARANTINE_SIZE_GB=5,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_uppercase_hash_matches_existing_lowercase_row(self, mock_http_class, mock_usage):
+        """An uppercase hash from the server must not re-insert a known payload."""
+        HoneypotPayload.objects.create(sha256="a" * 64)
+
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [
+            {"sha256": "A" * 64, "locator": "cowrie/aaa"},
+        ]
+        mock_client.get.return_value = mock_metadata_resp
+        mock_usage.return_value = 0
+
+        self.job.run()
+
+        # Recognised as a duplicate: nothing inserted, no download attempted.
+        self.assertEqual(HoneypotPayload.objects.count(), 1)
+        self.assertEqual(mock_client.get.call_count, 1)
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="",
+        MAX_QUARANTINE_SIZE_GB=5,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_lowercase_hash_matches_existing_uppercase_row(self, mock_http_class, mock_usage):
+        """Rows stored in upper case before the fix must still be matched."""
+        HoneypotPayload.objects.create(sha256="B" * 64)
+
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [
+            {"sha256": "b" * 64, "locator": "cowrie/bbb"},
+        ]
+        mock_client.get.return_value = mock_metadata_resp
+        mock_usage.return_value = 0
+
+        self.job.run()
+
+        self.assertEqual(HoneypotPayload.objects.count(), 1)
+        self.assertEqual(mock_client.get.call_count, 1)
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="",
+        MAX_QUARANTINE_SIZE_GB=5,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_new_payload_is_stored_lower_cased(self, mock_http_class, mock_usage):
+        """A new uppercase hash should be persisted in lower case."""
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [
+            {"sha256": "C" * 64, "locator": "cowrie/ccc"},
+        ]
+        mock_download_resp = Mock()
+        mock_download_resp.content = b"\xde\xad"
+        mock_client.get.side_effect = [mock_metadata_resp, mock_download_resp]
+        mock_usage.return_value = 0
+
+        self.job.run()
+
+        self.assertEqual(HoneypotPayload.objects.count(), 1)
+        payload = HoneypotPayload.objects.get()
+        self.assertEqual(payload.sha256, "c" * 64)
+        self.assertIn("c" * 64, payload.payload_file.name)
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="",
+        MAX_QUARANTINE_SIZE_GB=5,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_same_hash_in_different_cases_within_one_batch(self, mock_http_class, mock_usage):
+        """Two entries differing only in case must collapse into a single insert."""
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [
+            {"sha256": "d" * 64, "locator": "cowrie/ddd"},
+            {"sha256": "D" * 64, "locator": "cowrie/DDD"},
+        ]
+        mock_download_resp = Mock()
+        mock_download_resp.content = b"\xbe\xef"
+        mock_client.get.side_effect = [mock_metadata_resp, mock_download_resp]
+        mock_usage.return_value = 0
+
+        self.job.run()
+
+        self.assertEqual(HoneypotPayload.objects.count(), 1)
+        self.assertEqual(HoneypotPayload.objects.get().sha256, "d" * 64)
+        # One metadata request plus exactly one download.
+        self.assertEqual(mock_client.get.call_count, 2)
 
 
 class TestExtractAllPayloadIntegration(CustomTestCase):


### PR DESCRIPTION
# Description

HoneypotPayload is unique on Lower("sha256"), but the dedup check looked up hashes case-sensitively and stored them exactly as the payload server sent them. So an uppercase hash for a payload already saved in lower case slipped past dedup, hit the insert, and broke the constraint.

That kills more than one payload. The save has no error handling and the cronjob re-raises, so one bad hash ends the whole run and the rest of the batch is dropped.

Fix normalizes both sides: incoming hashes get lower-cased, and existing rows are matched on Lower("sha256"). That second bit is a little beyond the issue, but without it any mixed-case row already in the DB would still slip through.

kept this to case normalization only, as agreed in #1556, the get_or_create change stays with #1530

### Related issues

Closes #1556

Related: #1530 (get_or_create is left out on purpose), #1552 (also touches payload_extraction.py)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### Tests

5 new tests. No case-sensitivity coverage existed before.

I checked they are real regression tests by reverting the fix and rerunning themwith the tests untouched, all four behavioural ones fail, including the 'CCCC…' != 'cccc…' assertion.