### PR TITLE
Extract shared base class for enrichment cronjobs. Closes #1566

### DIFF
--- a/greedybear/cronjobs/abuseipdb_feed.py
+++ b/greedybear/cronjobs/abuseipdb_feed.py
@@ -1,16 +1,15 @@
 import requests
 from django.conf import settings
 
-from greedybear.cronjobs.base import Cronjob
+from greedybear.cronjobs.base_enrichment import BaseEnrichmentCron
 from greedybear.cronjobs.http_client import HttpClient
-from greedybear.cronjobs.repositories.tag import TagRepository
 from greedybear.models import IOC
 from greedybear.utils import is_valid_ipv4
 
 SOURCE_NAME = "abuseipdb"
 
 
-class AbuseIPDBCron(Cronjob):
+class AbuseIPDBCron(BaseEnrichmentCron):
     """
     Fetch AbuseIPDB blocklist and directly enrich matching IOCs with tags.
 
@@ -21,16 +20,6 @@ class AbuseIPDBCron(Cronjob):
     """
 
     MAX_ENTRIES = 10000  # Hard limit as per free API tier
-
-    def __init__(self, tag_repo=None):
-        """
-        Initialize the AbuseIPDB cronjob.
-
-        Args:
-            tag_repo: Optional TagRepository instance for testing.
-        """
-        super().__init__()
-        self.tag_repo = tag_repo if tag_repo is not None else TagRepository()
 
     def run(self) -> None:
         """

--- a/greedybear/cronjobs/base_enrichment.py
+++ b/greedybear/cronjobs/base_enrichment.py
@@ -1,0 +1,17 @@
+from greedybear.cronjobs.base import Cronjob
+from greedybear.cronjobs.repositories.tag import TagRepository
+
+
+class BaseEnrichmentCron(Cronjob):
+    """
+    Shared base for enrichment cronjobs that write Tag records.
+
+    Handles the common tag_repo initialization used by ThreatFox,
+    AbuseIPDB, reverse DNS, and credential reuse jobs. Subclasses
+    must still implement run(), inherited as abstract from Cronjob.
+    This avoids repetitive code.
+    """
+
+    def __init__(self, tag_repo=None):
+        super().__init__()
+        self.tag_repo = tag_repo if tag_repo is not None else TagRepository()

--- a/greedybear/cronjobs/credential_reuse.py
+++ b/greedybear/cronjobs/credential_reuse.py
@@ -1,7 +1,6 @@
 from django.db.models import Count
 
-from greedybear.cronjobs.base import Cronjob
-from greedybear.cronjobs.repositories.tag import TagRepository
+from greedybear.cronjobs.base_enrichment import BaseEnrichmentCron
 from greedybear.models import IOC, IocType
 
 # source name used for tagging
@@ -16,7 +15,7 @@ MIN_CREDENTIAL_REUSE = 10
 MAX_CANDIDATES = 500
 
 
-class CredentialReuseCron(Cronjob):
+class CredentialReuseCron(BaseEnrichmentCron):
     """
     Experimental heuristic to highlight IPs that:
     - perform repeated login attempts
@@ -27,10 +26,6 @@ class CredentialReuseCron(Cronjob):
     to help analyze patterns in login activity, not a
     definitive classification of attacker behavior.
     """
-
-    def __init__(self, tag_repo=None):
-        super().__init__()
-        self.tag_repo = tag_repo or TagRepository()
 
     def run(self) -> None:
         candidates = self._get_candidates()

--- a/greedybear/cronjobs/reverse_dns.py
+++ b/greedybear/cronjobs/reverse_dns.py
@@ -4,9 +4,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from django.db.models import F
 
 from greedybear.consts import MASS_SCANNER_DOMAINS
-from greedybear.cronjobs.base import Cronjob
+from greedybear.cronjobs.base_enrichment import BaseEnrichmentCron
 from greedybear.cronjobs.repositories import IocRepository
-from greedybear.cronjobs.repositories.tag import TagRepository
 from greedybear.enums import IpReputation
 from greedybear.models import IOC, IocType
 
@@ -22,7 +21,7 @@ DNS_TIMEOUT = 2
 SOURCE_NAME = "rdns"
 
 
-class ReverseDNSCron(Cronjob):
+class ReverseDNSCron(BaseEnrichmentCron):
     """
     Identify mass scanning services via reverse DNS lookups.
 
@@ -42,8 +41,7 @@ class ReverseDNSCron(Cronjob):
             tag_repo: Optional TagRepository instance for testing.
             ioc_repo: Optional IocRepository instance for testing.
         """
-        super().__init__()
-        self.tag_repo = tag_repo if tag_repo is not None else TagRepository()
+        super().__init__(tag_repo)
         self.ioc_repo = ioc_repo if ioc_repo is not None else IocRepository()
 
     def run(self) -> None:

--- a/greedybear/cronjobs/threatfox_feed.py
+++ b/greedybear/cronjobs/threatfox_feed.py
@@ -4,16 +4,15 @@ from ipaddress import ip_address
 import requests
 from django.conf import settings
 
-from greedybear.cronjobs.base import Cronjob
+from greedybear.cronjobs.base_enrichment import BaseEnrichmentCron
 from greedybear.cronjobs.http_client import HttpClient
-from greedybear.cronjobs.repositories.tag import TagRepository
 from greedybear.models import IOC
 from greedybear.utils import is_valid_ipv4
 
 SOURCE_NAME = "threatfox"
 
 
-class ThreatFoxCron(Cronjob):
+class ThreatFoxCron(BaseEnrichmentCron):
     """
     Fetch ThreatFox IOC data and directly enrich matching IOCs with tags.
 
@@ -22,16 +21,6 @@ class ThreatFoxCron(Cronjob):
     replaced on successful API responses; on errors or non-OK status,
     existing tags are preserved to avoid losing enrichment data.
     """
-
-    def __init__(self, tag_repo=None):
-        """
-        Initialize the ThreatFox cronjob.
-
-        Args:
-            tag_repo: Optional TagRepository instance for testing.
-        """
-        super().__init__()
-        self.tag_repo = tag_repo if tag_repo is not None else TagRepository()
 
     def run(self) -> None:
         """


### PR DESCRIPTION
# Description

threatfox_feed.py, abuseipdb_feed.py, reverse_dns.py, and credential_reuse.py all shared one identical line in their __init__:

self.tag_repo = tag_repo if tag_repo is not None else TagRepository()

I created a new BaseEnrichmentCron class (extending Cronjob) in base_enrichment.py holding this shared init logic. The 4 files now extend BaseEnrichmentCron instead of Cronjob directly:

- threatfox_feed.py, abuseipdb_feed.py, credential_reuse.py had their __init__ removed entirely
- reverse_dns.py kept its own __init__ for the extra ioc_repo dependency, simplified to call super().__init__(tag_repo)

Pure refactor, no behavior changes found. I ran a Full test suite and it passes (1329/1329).


### Related issues

Progresses #1551 
Closes #1566 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist


### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes
No GUI changes

  
# Review process

Opening this as a draft since it only shares init for now. Maybe will try extending it to share more of the run() logic and see how that looks with real code before deciding if its worth it.


