### PR TITLE
Keep metadata for payloads skipped at quarantine quota. Closes #1532

### DIFF
--- a/greedybear/cronjobs/payload_extraction.py
+++ b/greedybear/cronjobs/payload_extraction.py
@@ -27,8 +27,10 @@ class PayloadExtractionJob(Cronjob):
     3. Checks quarantine disk usage against MAX_QUARANTINE_SIZE_GB before downloading.
     4. Downloads new payload files via ``/api/v1/payloads/download/{locator}``
        and saves them via QuarantineStorage.
-    5. Links each downloaded payload to any Cowrie sessions that already
-       transferred a file with the same SHA256.
+    5. Records metadata-only rows for any payload left undownloaded once the
+       quota is reached, so it is not lost with the extraction window.
+    6. Links every payload it records, downloaded or not, to the Cowrie sessions
+       and attacker IOCs that already transferred a file with the same SHA256.
     """
 
     # Timeout for the metadata listing request (seconds).
@@ -66,10 +68,15 @@ class PayloadExtractionJob(Cronjob):
             # Step 3: Download and store each new payload.
             downloaded = 0
             skipped_count = 0
-            for payload_meta in new_payloads:
+            deferred_count = 0
+            for index, payload_meta in enumerate(new_payloads):
                 # Check disk usage before each download.
                 if self._quarantine_usage_bytes() >= max_size_bytes:
                     self.log.error(f"Quarantine directory has reached the {settings.MAX_QUARANTINE_SIZE_GB} GB limit. Stopping downloads.")
+                    # Record what we did not get to. Every payload shows up in exactly
+                    # one /recent window, so dropping the rest of the batch here would
+                    # lose these files permanently.
+                    deferred_count = self._store_metadata_only(new_payloads[index:])
                     break
 
                 if self._download_and_store(client, server_url, payload_meta):
@@ -77,7 +84,7 @@ class PayloadExtractionJob(Cronjob):
                 else:
                     skipped_count += 1
 
-        self.log.info(f"Payload extraction complete: {downloaded} downloaded, {skipped_count} skipped/failed.")
+        self.log.info(f"Payload extraction complete: {downloaded} downloaded, {skipped_count} skipped/failed, {deferred_count} stored as metadata only.")
 
     def _build_auth_headers(self) -> dict:
         """
@@ -165,6 +172,67 @@ class PayloadExtractionJob(Cronjob):
         if not quarantine_path.is_dir():
             return 0
         return sum(f.stat().st_size for f in quarantine_path.iterdir() if f.is_file())
+
+    def _store_metadata_only(self, payloads: list[dict]) -> int:
+        """
+        Persist metadata-only rows for payloads that were not downloaded.
+
+        Called when the quarantine quota is exhausted mid-batch. The row keeps the
+        locator, which is the only handle the file can be fetched with later, and
+        leaves ``payload_file`` empty to mark the payload as not yet downloaded.
+
+        Each row is linked to the Cowrie sessions and attacker IOCs that already
+        transferred the same file, exactly as a downloaded payload would be. The
+        hash is what the join runs on, so a row without a file still carries the
+        attribution; the file only fills in later.
+
+        Args:
+            payloads: List of payload metadata dicts that were not downloaded.
+
+        Returns:
+            int: Number of payloads recorded.
+        """
+        stored = 0
+        for payload_meta in payloads:
+            # Lower-cased like in _deduplicate, so every writer agrees on the case.
+            sha256 = payload_meta["sha256"].lower()
+            locator = payload_meta.get("locator", "")
+
+            if not locator:
+                # Without a locator the file can never be fetched, so a row would
+                # only shadow the hash without offering a way to recover it.
+                self.log.warning(f"Payload {sha256[:12]}… has no locator, skipping.")
+                continue
+
+            payload_obj, created = HoneypotPayload.objects.get_or_create(
+                sha256=sha256,
+                defaults={
+                    # NULL rather than "", to match the hash-only stubs written by
+                    # _process_payload_hashes. The field still expresses "no file"
+                    # two ways across the codebase; unifying that is a follow-up.
+                    "payload_file": None,
+                    "md5": payload_meta.get("md5", ""),
+                    "sha1": payload_meta.get("sha1", ""),
+                    "mime_type": payload_meta.get("mime_type", ""),
+                    "size": payload_meta.get("size"),
+                    "locator": locator,
+                    "mtime": payload_meta.get("mtime"),
+                },
+            )
+            if not created and not payload_obj.locator:
+                # A hash-only stub written by _process_payload_hashes carries no
+                # locator. Fill it in so the payload stays recoverable.
+                payload_obj.locator = locator
+                payload_obj.save(update_fields=["locator"])
+
+            linked = self.payload_repo.link_sessions_to_payload(payload_obj)
+            if linked:
+                self.log.info(f"Linked payload {sha256[:12]}… to {linked} cowrie session(s).")
+            stored += 1
+
+        if stored:
+            self.log.info(f"Stored metadata for {stored} payload(s) that were not downloaded.")
+        return stored
 
     def _download_and_store(self, client: HttpClient, server_url: str, payload_meta: dict) -> bool:
         """

--- a/tests/test_payload_extraction.py
+++ b/tests/test_payload_extraction.py
@@ -213,8 +213,143 @@ class TestPayloadExtractionJob(CustomTestCase):
             self.job.run()
 
         mock_error.assert_called_once_with("Quarantine directory has reached the 0.001 GB limit. Stopping downloads.")
-        # No payload should have been downloaded.
+        # Only the metadata request was made, no download was attempted.
+        self.assertEqual(mock_client.get.call_count, 1)
+        # The payload is kept as metadata only so it is not lost with the window.
+        obj = HoneypotPayload.objects.get(sha256="d" * 64)
+        self.assertFalse(obj.payload_file)
+        self.assertEqual(obj.locator, "cowrie/ddd")
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="",
+        MAX_QUARANTINE_SIZE_GB=0.001,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_stores_metadata_for_whole_remaining_batch(self, mock_http_class, mock_usage):
+        """Every payload left undownloaded when the quota trips should be recorded."""
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [
+            {"sha256": "d" * 64, "locator": "cowrie/ddd", "md5": "d" * 32, "sha1": "d" * 40, "mime_type": "application/x-executable", "mtime": 1234.5},
+            {"sha256": "e" * 64, "locator": "cowrie/eee"},
+            {"sha256": "f" * 64, "locator": "cowrie/fff"},
+        ]
+        mock_client.get.return_value = mock_metadata_resp
+        mock_usage.return_value = 2_000_000
+
+        self.job.run()
+
+        # All three are recorded, none downloaded. payload_file expresses "no file"
+        # as both "" and NULL today, so check falsiness rather than one of the two.
+        self.assertEqual(HoneypotPayload.objects.count(), 3)
+        self.assertTrue(all(not p.payload_file for p in HoneypotPayload.objects.all()))
+        # Metadata from the listing is carried over to the stub.
+        obj = HoneypotPayload.objects.get(sha256="d" * 64)
+        self.assertEqual(obj.md5, "d" * 32)
+        self.assertEqual(obj.sha1, "d" * 40)
+        self.assertEqual(obj.mime_type, "application/x-executable")
+        self.assertEqual(obj.mtime, 1234.5)
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="",
+        MAX_QUARANTINE_SIZE_GB=0.001,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_downloads_until_quota_then_stores_metadata(self, mock_http_class, mock_usage):
+        """Payloads downloaded before the quota trips keep their file, the rest do not."""
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [
+            {"sha256": "a" * 64, "locator": "cowrie/aaa"},
+            {"sha256": "b" * 64, "locator": "cowrie/bbb"},
+        ]
+        mock_download_resp = Mock()
+        mock_download_resp.content = b"\x00" * 128
+        mock_client.get.side_effect = [mock_metadata_resp, mock_download_resp]
+
+        # Under the limit for the first payload, over it for the second.
+        mock_usage.side_effect = [0, 2_000_000]
+
+        self.job.run()
+
+        downloaded = HoneypotPayload.objects.get(sha256="a" * 64)
+        self.assertTrue(downloaded.payload_file)
+        self.assertEqual(downloaded.size, 128)
+
+        deferred = HoneypotPayload.objects.get(sha256="b" * 64)
+        self.assertFalse(deferred.payload_file)
+        self.assertEqual(deferred.locator, "cowrie/bbb")
+
+    def test_metadata_only_skips_payload_without_locator(self):
+        """A payload with no locator can never be fetched, so no row is written."""
+        stored = self.job._store_metadata_only([{"sha256": "c" * 64, "locator": ""}])
+
+        self.assertEqual(stored, 0)
         self.assertEqual(HoneypotPayload.objects.count(), 0)
+
+    def test_metadata_only_links_cowrie_session(self):
+        """A payload recorded without its file still gets its session and IOC links."""
+        CowrieFileTransfer.objects.create(
+            session=self.cowrie_session,
+            shasum="c" * 64,
+            url="",
+            outfile="",
+            timestamp=timezone.now(),
+        )
+
+        stored = self.job._store_metadata_only([{"sha256": "c" * 64, "locator": "cowrie/ccc"}])
+
+        self.assertEqual(stored, 1)
+        obj = HoneypotPayload.objects.get(sha256="c" * 64)
+        self.assertFalse(obj.payload_file)
+        self.assertIn(self.cowrie_session, obj.cowrie_sessions.all())
+        self.assertIn(self.cowrie_session.source, obj.iocs.all())
+
+    def test_metadata_only_links_existing_stub_to_session(self):
+        """An existing hash-only stub picked up here is linked as well, not just new rows."""
+        HoneypotPayload.objects.create(sha256="c" * 64)
+        CowrieFileTransfer.objects.create(
+            session=self.cowrie_session,
+            shasum="c" * 64,
+            url="",
+            outfile="",
+            timestamp=timezone.now(),
+        )
+
+        stored = self.job._store_metadata_only([{"sha256": "c" * 64, "locator": "cowrie/ccc"}])
+
+        self.assertEqual(stored, 1)
+        obj = HoneypotPayload.objects.get(sha256="c" * 64)
+        self.assertIn(self.cowrie_session, obj.cowrie_sessions.all())
+        self.assertIn(self.cowrie_session.source, obj.iocs.all())
+
+    def test_metadata_only_is_idempotent(self):
+        """Recording the same payload twice should not create a duplicate row."""
+        payloads = [{"sha256": "c" * 64, "locator": "cowrie/ccc"}]
+
+        self.assertEqual(self.job._store_metadata_only(payloads), 1)
+        self.assertEqual(self.job._store_metadata_only(payloads), 1)
+        self.assertEqual(HoneypotPayload.objects.filter(sha256="c" * 64).count(), 1)
+
+    def test_metadata_only_fills_locator_on_existing_stub(self):
+        """A hash-only stub gets its locator filled in so it stays recoverable."""
+        HoneypotPayload.objects.create(sha256="c" * 64)
+
+        stored = self.job._store_metadata_only([{"sha256": "C" * 64, "locator": "cowrie/ccc"}])
+
+        self.assertEqual(stored, 1)
+        obj = HoneypotPayload.objects.get(sha256="c" * 64)
+        self.assertEqual(obj.locator, "cowrie/ccc")
 
     @override_settings(
         TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",


### PR DESCRIPTION
## Description

When the quarantine directory reaches `MAX_QUARANTINE_SIZE_GB`, `PayloadExtractionJob.run()` is invoked to `break` out of the download loop and silently drop all remaining payloads in the batch.

That loss is permanent. `_fetch_metadata` builds its window as `end_ts = time.time()` and `start_ts = end_ts - (EXTRACTION_INTERVAL * 60)`, and the job is scheduled at that same interval, so the windows are strictly sequential and non-overlapping. Each payload, therefore, appears in exactly one `/recent` window. Once a window is skipped, there is no cursor, no overlap and no retry path, so those files are never seen again.

This PR makes the job record what it did not download, rather than discarding it.

Key details:

- `run()` now passes the unprocessed remainder of the batch to a new `_store_metadata_only()` helper before breaking out of the loop.
- `_store_metadata_only()` writes rows with `payload_file` left empty and preserves the `locator`, which is the only handle the file can be fetched with later and exactly what was being thrown away. It also carries over `md5`, `sha1`, `mime_type`, `size` and `mtime` from the listing.
- Payloads with no locator are skipped rather than stored, since such a row would shadow the hash without offering any way to recover the file. This matches the existing behaviour in `_download_and_store`.
- The helper uses `get_or_create`, so a concurrent write from `_process_payload_hashes` cannot raise an `IntegrityError` against the `Lower("sha256")` unique constraint. If it finds an existing hash-only stub with no locator, it fills the locator in so the payload stays recoverable.
- Hashes are lower-cased on the way in, consistent with the normalisation added in #1556.
- The `log.error` call and its message are left untouched, since the quota notification added in #1555 depends on them.
- The completion log line now reports the deferred count separately from `skipped_count`, which already means "download failed".

### Note on scope

This PR only preserves the metadata. It does not add a sweep that retries these rows later. As discussed in #1532, nothing currently deletes quarantine files, so a sweep would find no freed quota to use until an admin removes files or raises the limit. That is tracked separately.

This also interacts with #1530: `_deduplicate` currently skips any hash that has at least one row, so the rows written here are not yet picked up for download. Both changes should ship in the same release.

## Related issues

- Closes #1532
- Related to #1530, which should ship in the same release
- Builds on #1555 and #1556, which touch the same code path

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

## Checklist

### Formalities

- [x] I have read and understood the rules about how to contribute to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behaviour that is described in the docs. If so, I also included an update to the wiki in this PR's description.
- [x] Linter (Ruff) gave 0 errors. If you have installed pre-commit correctly, it performs these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

Tests added and updated in `tests/test_payload_extraction.py`

### GUI changes

N/A