### PR TITLE
Normalize SHA256 case in payload API lookups. Closes #1579

### DIFF
--- a/api/views/payloads.py
+++ b/api/views/payloads.py
@@ -2,11 +2,13 @@
 # See the file 'LICENSE' for copying permission.
 import logging
 
+from django.db.models.functions import Lower
 from django.http import FileResponse
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -53,6 +55,20 @@ class HoneypotPayloadViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = HoneypotPayloadSerializer
     permission_classes = [IsAuthenticated]
     lookup_field = "sha256"
+
+    def get_object(self) -> HoneypotPayload:
+        """
+        Look up the payload by SHA256, ignoring case.
+
+        The hash comes from the URL so it can be any case, while stored hashes
+        are lower-cased. Matching on Lower("sha256") also finds older rows that
+        were saved before that was true.
+        """
+        queryset = self.filter_queryset(self.get_queryset())
+        sha256 = self.kwargs[self.lookup_field].lower()
+        obj = get_object_or_404(queryset.annotate(sha256_lower=Lower("sha256")), sha256_lower=sha256)
+        self.check_object_permissions(self.request, obj)
+        return obj
 
     @extend_schema(
         summary="Download payload binary",

--- a/tests/api/views/test_payload_view.py
+++ b/tests/api/views/test_payload_view.py
@@ -85,6 +85,32 @@ class TestRetrievePayload(HoneypotPayloadViewSetTestCase):
         response = self.client.get(f"{PAYLOADS_URL}/{'0' * 64}")
         self.assertEqual(response.status_code, 404)
 
+    # The hash comes from the URL so it can be any case, but stored hashes are
+    # lower-cased. Without a case-insensitive lookup a valid request 404s (#1579).
+
+    def test_retrieve_by_uppercase_sha256(self):
+        """Uppercase hash in the URL should still find the row."""
+        self.client.force_authenticate(user=self.regular_user)
+        response = self.client.get(f"{PAYLOADS_URL}/{SAMPLE_SHA256.upper()}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["sha256"], SAMPLE_SHA256)
+
+    def test_retrieve_by_mixed_case_sha256(self):
+        """Mixed case should work too, not just all uppercase."""
+        self.client.force_authenticate(user=self.regular_user)
+        mixed = "".join(c.upper() if i % 2 else c for i, c in enumerate(SAMPLE_SHA256))
+        response = self.client.get(f"{PAYLOADS_URL}/{mixed}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["sha256"], SAMPLE_SHA256)
+
+    def test_retrieve_finds_row_stored_uppercase(self):
+        """Older rows saved in uppercase should still be found."""
+        legacy = HoneypotPayload.objects.create(sha256="E" * 64)
+        self.client.force_authenticate(user=self.regular_user)
+        response = self.client.get(f"{PAYLOADS_URL}/{'e' * 64}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["sha256"], legacy.sha256)
+
 
 class TestDownloadPayload(HoneypotPayloadViewSetTestCase):
     def test_unauthenticated_is_rejected(self):
@@ -122,3 +148,21 @@ class TestDownloadPayload(HoneypotPayloadViewSetTestCase):
         response = self.client.get(f"{PAYLOADS_URL}/{SAMPLE_SHA256}/download")
         self.assertEqual(response.status_code, 404)
         self.assertIn("not available", response.json()["detail"])
+
+    # download uses the same lookup as retrieve, so it needs the same checks.
+
+    def test_staff_can_download_with_uppercase_hash(self):
+        """Uppercase should work on the download route too."""
+        self.client.force_authenticate(user=self.superuser)
+        sha = self.payload_with_file.sha256
+        response = self.client.get(f"{PAYLOADS_URL}/{sha.upper()}/download")
+        self.assertEqual(response.status_code, 200)
+        content = b"".join(response.streaming_content)
+        self.assertEqual(content, b"MZ\x90\x00")
+
+    def test_uppercase_hash_still_enforces_permissions(self):
+        """Case-insensitive lookup must not bypass the RBAC check."""
+        self.client.force_authenticate(user=self.regular_user)
+        sha = self.payload_with_file.sha256
+        response = self.client.get(f"{PAYLOADS_URL}/{sha.upper()}/download")
+        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
# Description

`/api/payloads/{sha256}` matched the hash exactly, so an uppercase hash from a user returned 404 even when the payload was there. Stored hashes are lower-cased on write, so anything not already lowercase missed

fixed by overriding `get_object` to lowercase the URL value and match on Lower("sha256"), matching on Lower() also covers older rows that were saved before hashes got normalized

This fixes `download` too, since it resolves the payload through the same `get_object()`

### Related issues

Closes #1579

Related: #1556 (same hash casing problem, but on the write side)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### Tests

5 new tests: uppercase URL, mixed case URL, a row stored uppercase, uppercase on the download route, and one checking the RBAC gate still applies since I rewrote the method that calls check_object_permissions.

also I reverted the fix and reran to confirm they are real, 4 of 5 fail without it. The RBAC one passes either way by design, it guards my change rather than the original bug. 
