### PR TITLE
Allow querying Cowrie sessions by ID. Closes #1578

### DIFF
--- a/api/serializers/cowrie_session.py
+++ b/api/serializers/cowrie_session.py
@@ -3,12 +3,20 @@ from rest_framework import serializers
 
 class CowrieSessionRequestSerializer(serializers.Serializer):
     query = serializers.CharField(
+        required=False,
         max_length=256,
         help_text=(
             "The search term, can be an IP address, the SHA-256 hash of a command sequence, or a password. "
-            'SHA-256 hashes should match command sequences generated using Python\'s `"\n".join(sequence)` format.'
+            'SHA-256 hashes should match command sequences generated using Python\'s `"\n".join(sequence)` format. '
+            "Mutually exclusive with `id`."
         ),
     )
+    id = serializers.CharField(
+        required=False,
+        max_length=32,
+        help_text=("Hex session ID, in the same format the payloads API returns. Mutually exclusive with `query`."),
+    )
+
     include_similar = serializers.BooleanField(
         required=False,
         default=False,
@@ -25,6 +33,20 @@ class CowrieSessionRequestSerializer(serializers.Serializer):
         required=False, default=False, help_text="When `true`, includes detailed information about matching Cowrie sessions."
     )
 
+    def validate_id(self, value: str) -> str:
+        """Session IDs are stored as integers, so the hex has to parse."""
+        try:
+            int(value, 16)
+        except ValueError as exc:
+            raise serializers.ValidationError(f"Not a valid hex session ID: {value}") from exc
+        return value
+
+    def validate(self, data: dict) -> dict:
+        """Exactly one of query or id, they select different things."""
+        if bool(data.get("query")) == bool(data.get("id")):
+            raise serializers.ValidationError("Provide either `query` or `id`, not both.")
+        return data
+
 
 class SessionDetailSerializer(serializers.Serializer):
     """A single matching Cowrie session."""
@@ -40,7 +62,8 @@ class SessionDetailSerializer(serializers.Serializer):
 class CowrieSessionSerializer(serializers.Serializer):
     """Aggregated view of the sessions matching a query."""
 
-    query = serializers.CharField(max_length=256, help_text="The query this result was produced for.")
+    query = serializers.CharField(required=False, max_length=256, help_text="The query this result was produced for. Present when searching by `query`.")
+    id = serializers.CharField(required=False, max_length=32, help_text="The session ID this result was produced for. Present when searching by `id`.")
     license = serializers.CharField(required=False, help_text="Present when a feed license is configured.")
     commands = serializers.ListField(child=serializers.CharField(), help_text="Unique command sequences, each newline-delimited.")
     sources = serializers.ListField(child=serializers.IPAddressField(), help_text="Unique source IP addresses.")

--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -27,12 +27,14 @@ from greedybear.utils import is_ip_address, is_sha256hash
             "Retrieve Cowrie honeypot session data including command sequences, credentials, and session details. "
             "Queries can be performed using an IP address to find all sessions from that source, "
             "a SHA-256 hash to find sessions containing a specific command sequence, "
-            "or a password to find all sessions where that password was used."
+            "or a password to find all sessions where that password was used. "
+            "Alternatively, pass `id` to look up one specific session by its hex ID, "
+            "as returned by the payloads API."
         ),
         parameters=[CowrieSessionRequestSerializer],
         responses={
             200: CowrieSessionSerializer,
-            400: OpenApiResponse(description="Missing or invalid `query` parameter."),
+            400: OpenApiResponse(description="Missing or invalid `query`/`id` parameter, or both were given."),
             401: OpenApiResponse(description="Authentication credentials were not provided or are invalid."),
             404: OpenApiResponse(description="No matching sessions found."),
         },
@@ -47,8 +49,16 @@ class CowrieSessionView(RequestLoggingMixin, APIView):
         request_serializer.is_valid(raise_exception=True)
         save_request_source(request, ViewType.COWRIE_SESSION_VIEW.value)
 
-        observable = request_serializer.validated_data["query"]
-        if is_ip_address(observable):
+        session_id = request_serializer.validated_data.get("id")
+        observable = request_serializer.validated_data.get("query")
+
+        if session_id is not None:
+            # A session ID points at one specific session, so no duration filter here.
+            sessions = CowrieSession.objects.filter(session_id=int(session_id, 16)).prefetch_related("source", "commands", "credentials")
+            if not sessions.exists():
+                raise Http404(f"No session found with ID: {session_id}")
+
+        elif is_ip_address(observable):
             sessions = CowrieSession.objects.filter(source__name=observable, duration__gt=0).prefetch_related("source", "commands", "credentials")
             if not sessions.exists():
                 raise Http404(f"No information found for IP: {observable}")
@@ -72,9 +82,7 @@ class CowrieSessionView(RequestLoggingMixin, APIView):
             )
             sessions = sessions.union(related_sessions)
 
-        data = {
-            "query": observable,
-        }
+        data = {"id": session_id} if session_id is not None else {"query": observable}
         if settings.FEEDS_LICENSE:
             data["license"] = settings.FEEDS_LICENSE
 

--- a/tests/api/views/test_cowrie_session_view.py
+++ b/tests/api/views/test_cowrie_session_view.py
@@ -165,6 +165,58 @@ class CowrieSessionViewTestCase(CustomTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("credentials", response.data)
 
+    # # # # # Session ID Query Tests # # # # #
+    def test_id_query(self):
+        """Test lookup of a single session by its hex ID."""
+        response = self.client.get("/api/cowrie_session?id=ffffffffffff")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], "ffffffffffff")
+        self.assertNotIn("query", response.data)
+        self.assertEqual(response.data["sources"], [self.ioc.name])
+
+    def test_id_query_with_session_data(self):
+        """Test that the ID lookup returns the matching session only."""
+        response = self.client.get("/api/cowrie_session?id=ffffffffffff&include_session_data=true")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["sessions"]), 1)
+        self.assertEqual(response.data["sessions"][0]["source"], self.ioc.name)
+
+    def test_id_query_returns_session_with_zero_duration(self):
+        """Sessions with no duration are still returned when asked for by ID."""
+        session = CowrieSession.objects.create(
+            session_id=int("abc123", 16),
+            start_time=self.current_time,
+            duration=0,
+            source=self.ioc,
+        )
+        response = self.client.get("/api/cowrie_session?id=abc123&include_session_data=true")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["sessions"]), 1)
+        session.delete()
+
+    def test_id_query_is_case_insensitive(self):
+        """Hex parses either case, so both should resolve to the same session."""
+        lower = self.client.get("/api/cowrie_session?id=ffffffffffff")
+        upper = self.client.get("/api/cowrie_session?id=FFFFFFFFFFFF")
+        self.assertEqual(lower.status_code, 200)
+        self.assertEqual(upper.status_code, 200)
+        self.assertEqual(lower.data["sources"], upper.data["sources"])
+
+    def test_nonexistent_id(self):
+        """Test that view returns 404 for an unknown session ID."""
+        response = self.client.get("/api/cowrie_session?id=abcdef123456")
+        self.assertEqual(response.status_code, 404)
+
+    def test_invalid_id_is_rejected(self):
+        """Non-hex IDs should be a validation error, not a 404."""
+        response = self.client.get("/api/cowrie_session?id=nothex")
+        self.assertEqual(response.status_code, 400)
+
+    def test_query_and_id_together_is_rejected(self):
+        """The two parameters select different things, so only one is allowed."""
+        response = self.client.get("/api/cowrie_session?query=140.246.171.141&id=ffffffffffff")
+        self.assertEqual(response.status_code, 400)
+
     # # # # # Hash Validation Tests # # # # #
     def test_nonexistent_hash(self):
         """Test that view returns 404 for nonexistent hash."""


### PR DESCRIPTION
# Description

The payloads API returns Cowrie session IDs, but there was no way to look a session up by one. I have added an `id` query parameter to /api/cowrie_session that takes the hex ID in the same format the payloads API returns

went with a separate parameter rather than another branch on `query`, since a hex ID and a password can look identical and the ID is not really an observable. `query` and `id` are mutually exclusive, giving both is a 400

The ID lookup does not apply the `duration__gt=0` filter other branches use, so asking for a specific session returns it either way

### Related issues

Closes #1578

Related to #1509 (added the session IDs to the payloads API that this consumes)

### Type of change

- [x] New feature (non-breaking change which adds functionality).

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### Tests

7 new tests: basic ID lookup, with session data, a zero-duration session still being returned, case-insensitive hex, unknown ID 404, non-hex 400, and both parameters together 400.

reverted the source and reran to check they're real, 6 of the 7 fail without it. The non-hex one passes either way since a request with no `query` was already a 400, but it is still the right assertion to keep.

Note: `id` shadows a builtin so I checked ruff's flake8-builtins rules, no complaints across all 205 files. Happy to rename if you would rather avoid it.