### PR TITLE
Add lookback_minutes parameter to Feeds API. Closes #1515

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -6,6 +6,8 @@ from django.utils import timezone
 
 from greedybear.models import IOC
 
+MINUTES_PER_DAY = 60 * 24
+
 
 class FeedsFilterSet(django_filters.FilterSet):
     asn = django_filters.NumberFilter(field_name="autonomous_system__asn")
@@ -16,6 +18,7 @@ class FeedsFilterSet(django_filters.FilterSet):
     tag_key = django_filters.CharFilter(field_name="tags__key", lookup_expr="iexact")
     tag_value = django_filters.CharFilter(field_name="tags__value", lookup_expr="icontains")
 
+    lookback_minutes = django_filters.NumberFilter(method="filter_lookback_minutes")
     attack_type = django_filters.CharFilter(method="filter_attack_type")
     ioc_type = django_filters.CharFilter(method="filter_ioc_type")
     port = django_filters.NumberFilter(method="filter_port")
@@ -66,9 +69,14 @@ class FeedsFilterSet(django_filters.FilterSet):
         qualifying = IOC.objects.annotate(cc=Count("credentials", distinct=True)).filter(**{f"cc__{lookup}": value}).values("id")
         return queryset.filter(id__in=qualifying)
 
+    def filter_lookback_minutes(self, queryset: QuerySet, name: str, value: int) -> QuerySet:
+        if value and int(value) > 0:
+            cutoff = timezone.now() - timedelta(minutes=int(value))
+            return queryset.filter(last_seen__gte=cutoff)
+        return queryset
+
     def filter_max_age(self, queryset: QuerySet, name: str, value: int) -> QuerySet:
-        # drop max_age id an explicit date range replaces is set
-        if self.data.get("start_date") or self.data.get("end_date"):
+        # drop max_age if an explicit date range or time window is set
+        if any(self.data.get(k) for k in ("start_date", "end_date", "lookback_minutes")):
             return queryset
-        cutoff = timezone.now() - timedelta(days=int(value))
-        return queryset.filter(last_seen__gte=cutoff)
+        return self.filter_lookback_minutes(queryset, name, int(value) * MINUTES_PER_DAY)

--- a/api/serializers/feeds.py
+++ b/api/serializers/feeds.py
@@ -134,6 +134,7 @@ class SimpleFeedRequestSerializer(BaseFeedRequestSerializer):
     include_tor_exit_nodes = PresenceFlagField(default=False, help_text="Include IOCs that are Tor exit nodes.")
     # allows explicit override of the ordering in PRIORITIZATION_PRESETS
     ordering = serializers.CharField(required=False, help_text="Override the preset ordering, e.g. `-attack_count`.")
+    lookback_minutes = serializers.IntegerField(required=False, min_value=1, allow_null=True, help_text="Filter IOCs seen since the last N minutes.")
 
     def validate(self, data: dict) -> dict:
         logger.debug("Validating simple feed request")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from hashlib import sha256
 from unittest.mock import Mock
 
@@ -106,6 +106,28 @@ class CustomTestCase(TestCase):
             attacker_country_code="US",
         )
 
+        cls.ioc_recent = IOC.objects.create(
+            name="101.101.101.101",
+            type=IocType.IP.value,
+            first_seen=cls.current_time - timedelta(minutes=10),
+            last_seen=cls.current_time - timedelta(minutes=10),
+            days_seen=[cls.current_time.date()],
+            number_of_days_seen=1,
+            attack_count=1,
+            scanner=True,
+        )
+
+        cls.ioc_old = IOC.objects.create(
+            name="102.102.102.102",
+            type=IocType.IP.value,
+            first_seen=cls.current_time - timedelta(days=5),
+            last_seen=cls.current_time - timedelta(days=5),
+            days_seen=[cls.current_time.date()],
+            number_of_days_seen=1,
+            attack_count=1,
+            scanner=True,
+        )
+
         cls.ioc_domain = IOC.objects.create(
             name="malicious.example.com",
             type=IocType.DOMAIN.value,
@@ -138,6 +160,8 @@ class CustomTestCase(TestCase):
         cls.ioc_2.save()
         cls.ioc_3.honeypots.add(cls.cowrie_hp)  # Cowrie honeypot
         cls.ioc_3.save()
+        cls.ioc_recent.save()
+        cls.ioc_old.save()
         cls.ioc_domain.honeypots.add(cls.heralding)  # FEEDS
         cls.ioc_domain.honeypots.add(cls.log4pot_hp)  # Log4pot honeypot
         cls.ioc_domain.save()

--- a/tests/api/views/test_feeds_view.py
+++ b/tests/api/views/test_feeds_view.py
@@ -138,6 +138,22 @@ class FeedsViewTestCase(CustomTestCase):
             # Verify all returned values are domains (contain alphabetic characters)
             self.assertRegex(ioc["value"], r"[a-zA-Z]")
 
+    def test_lookback_minutes_filters_correct_window(self):
+        response = self.client.get("/api/feeds/all/all/recent.json?lookback_minutes=30")
+        self.assertEqual(response.status_code, 200)
+
+        ioc_values = [ioc["value"] for ioc in response.json()["iocs"]]
+        self.assertIn("101.101.101.101", ioc_values)
+        self.assertNotIn("102.102.102.102", ioc_values)
+
+    def test_loockback_minutes_bypasses_default_max_age(self):
+        response = self.client.get("/api/feeds/all/all/recent.json?lookback_minutes=10000")
+        self.assertEqual(response.status_code, 200)
+
+        ioc_values = [ioc["value"] for ioc in response.json()["iocs"]]
+        self.assertIn("101.101.101.101", ioc_values)
+        self.assertIn("102.102.102.102", ioc_values)
+
     def test_200_feeds_pagination_filter_ip(self):
         response = self.client.get(
             "/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&ioc_type=ip&include_mass_scanners&include_tor_exit_nodes"


### PR DESCRIPTION
# Description

This PR adds a lookback_minutes optional query parameter to the Feeds API (e.g., /api/feeds/all/all/recent.json?lookback_minutes=30).

This functionality enables external integrations (such as IntelOwl or automated cron jobs) to fetch only the IOCs observed within a specific trailing time window from the query execution time.

### Related issues

#1515 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist
### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [ ] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [ ] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [ ] All the tests gave 0 errors.

