### PR TITLE
fix(api): return 400 Bad Request on malformed range parameter in statistics view

### DIFF
--- a/api/views/statistics.py
+++ b/api/views/statistics.py
@@ -8,6 +8,7 @@ from django.db.models.functions import Trunc
 from django.http import HttpResponseBadRequest
 from rest_framework import viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from api.mixins import CachedResponseMixin
@@ -189,6 +190,9 @@ class StatisticsViewSet(CachedResponseMixin, viewsets.ViewSet):
 
         Returns:
             tuple: A tuple containing the delta time and basis for the query range.
+
+        Raises:
+            ValidationError: If the range parameter cannot be parsed as a valid time range.
         """
         try:
             range_str = request.GET["range"]
@@ -196,4 +200,8 @@ class StatisticsViewSet(CachedResponseMixin, viewsets.ViewSet):
             # default
             range_str = "7d"
 
-        return parse_humanized_range(range_str)
+        try:
+            return parse_humanized_range(range_str)
+        except (ValueError, TypeError, KeyError, AttributeError) as exc:
+            logger.warning(f"Invalid range parameter '{range_str}': {exc}")
+            raise ValidationError(f"Invalid 'range' parameter: '{range_str}'. Expected format like '7d', '24h', or '30d'.") from exc

--- a/tests/api/views/test_statistics_view.py
+++ b/tests/api/views/test_statistics_view.py
@@ -90,6 +90,26 @@ class StatisticsViewTestCase(CustomTestCase):
         count_values = [item["count"] for item in data]
         self.assertEqual(count_values, sorted(count_values, reverse=True))
 
+    def test_400_invalid_range_countries(self):
+        response = self.client.get("/api/statistics/countries?range=invalid")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid 'range' parameter", str(response.json()))
+
+    def test_400_invalid_range_feeds_types(self):
+        response = self.client.get("/api/statistics/feeds_types?range=invalid")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid 'range' parameter", str(response.json()))
+
+    def test_400_invalid_range_feeds_sources(self):
+        response = self.client.get("/api/statistics/sources/feeds?range=invalid")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid 'range' parameter", str(response.json()))
+
+    def test_400_invalid_range_enrichment_sources(self):
+        response = self.client.get("/api/statistics/sources/enrichment?range=invalid")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid 'range' parameter", str(response.json()))
+
 
 @override_settings(CACHES=TEST_CACHES)
 class StatisticsIocCacheTestCase(CustomTestCase):


### PR DESCRIPTION
# Description

When an invalid or malformed `?range=` parameter (such as `?range=invalid` or `?range=abc`) is sent to the statistics API endpoints (`/api/statistics/countries`, `/api/statistics/feeds_types`, `/api/statistics/sources/feeds`, etc.), `parse_humanized_range()` raises an uncaught exception. This causes Django to return an unhandled HTTP 500 Internal Server Error.

This PR wraps `parse_humanized_range()` in a `try...except` block in `StatisticsViewSet.__parse_range()`. If the range string cannot be parsed, it now raises a DRF `ValidationError`, returning a clean HTTP 400 Bad Request with a clear message (`"Invalid 'range' parameter: '<val>'. Expected format like '7d', '24h', or '30d'."`).

Unit tests have also been added in `tests/api/views/test_statistics_view.py` to verify that invalid ranges return HTTP 400 across all statistics actions.

### Related issues

#1596 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

