### PR TITLE
fix: let payload extraction upgrade hash-only stubs instead of skipping them. Closes #1530

### DIFF
--- a/greedybear/cronjobs/payload_extraction.py
+++ b/greedybear/cronjobs/payload_extraction.py
@@ -125,8 +125,13 @@ class PayloadExtractionJob(Cronjob):
 
     def _deduplicate(self, payloads: list[dict]) -> list[dict]:
         """
-        Filter out payloads whose SHA256 already exists in the database
-        and remove duplicates within the response itself.
+        Filter out payloads whose SHA256 already has a downloaded file in the
+        database, and remove duplicates within the response itself.
+
+        A hash can already have a HoneypotPayload row without a file attached -
+        a metadata-only stub created from a raw event before the file was
+        available. Those hashes are treated as new so the file can still be
+        downloaded.
 
         Args:
             payloads: List of payload metadata dicts (must contain 'sha256' key).
@@ -140,7 +145,10 @@ class PayloadExtractionJob(Cronjob):
         # through to fail on the constraint instead.
         incoming_hashes = {p["sha256"].lower() for p in payloads if "sha256" in p}
         existing_hashes = set(
-            HoneypotPayload.objects.annotate(sha256_lower=Lower("sha256")).filter(sha256_lower__in=incoming_hashes).values_list("sha256_lower", flat=True)
+            HoneypotPayload.objects.annotate(sha256_lower=Lower("sha256"))
+            .filter(sha256_lower__in=incoming_hashes)
+            .exclude(payload_file="")  # Django stores an unset FileField as an empty string.
+            .values_list("sha256_lower", flat=True)
         )
         new_hashes = incoming_hashes - existing_hashes
         self.log.debug(f"Deduplication: {len(incoming_hashes)} incoming, {len(existing_hashes)} existing, {len(new_hashes)} new.")
@@ -168,8 +176,9 @@ class PayloadExtractionJob(Cronjob):
 
     def _download_and_store(self, client: HttpClient, server_url: str, payload_meta: dict) -> bool:
         """
-        Download a single payload file, create its database record, and link
-        it to any Cowrie sessions that already transferred the same file.
+        Download a single payload file, create its database record (or upgrade
+        an existing hash-only stub with the real file), and link it to any
+        Cowrie sessions that already transferred the same file.
 
         Args:
             client: HttpClient instance.
@@ -199,23 +208,33 @@ class PayloadExtractionJob(Cronjob):
 
         file_content = response.content
 
-        # Create the database record with metadata.
-        payload_obj = HoneypotPayload(
-            sha256=sha256,
-            md5=payload_meta.get("md5", ""),
-            sha1=payload_meta.get("sha1", ""),
-            mime_type=payload_meta.get("mime_type", ""),
-            size=len(file_content),
-            locator=locator,
-            mtime=payload_meta.get("mtime"),
-        )
+        # Upgrade the existing stub if one exists. The unique constraint is on
+        # Lower("sha256"), so a case-sensitive get_or_create(sha256=sha256) could
+        # miss a differently-cased row and hit IntegrityError on insert instead.
+        fields = {
+            "md5": payload_meta.get("md5", ""),
+            "sha1": payload_meta.get("sha1", ""),
+            "mime_type": payload_meta.get("mime_type", ""),
+            "size": len(file_content),
+            "locator": locator,
+            "mtime": payload_meta.get("mtime"),
+        }
+        payload_obj = HoneypotPayload.objects.annotate(sha256_lower=Lower("sha256")).filter(sha256_lower=sha256).first()
+        created = payload_obj is None
+        if created:
+            payload_obj = HoneypotPayload(sha256=sha256)
+        for field, value in fields.items():
+            setattr(payload_obj, field, value)
 
         # Save the binary content via QuarantineStorage.
         filename = f"{sha256}.vir"
         payload_obj.payload_file.save(filename, ContentFile(file_content), save=False)
         payload_obj.save()
 
-        self.log.info(f"Stored new payload {sha256[:12]}… ({len(file_content)} bytes).")
+        if created:
+            self.log.info(f"Stored new payload {sha256[:12]}… ({len(file_content)} bytes).")
+        else:
+            self.log.info(f"Upgraded hash-only stub {sha256[:12]}… with the downloaded file ({len(file_content)} bytes).")
 
         linked = self.payload_repo.link_sessions_to_payload(payload_obj)
         if linked:

--- a/tests/test_payload_extraction.py
+++ b/tests/test_payload_extraction.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import requests
+from django.core.files.base import ContentFile
 from django.test import override_settings
 from django.utils import timezone
 
@@ -166,8 +167,11 @@ class TestPayloadExtractionJob(CustomTestCase):
     @patch("greedybear.cronjobs.payload_extraction.HttpClient")
     def test_deduplicates_existing_payloads(self, mock_http_class, mock_usage):
         """Job should skip payloads that already exist in the database."""
-        # Pre-create a payload record.
-        HoneypotPayload.objects.create(sha256="a" * 64)
+        # Pre-create a payload record with a real file - a stub without one would
+        # now correctly be treated as still needing a download, not a duplicate.
+        existing = HoneypotPayload.objects.create(sha256="a" * 64)
+        existing.payload_file.save("existing.vir", ContentFile(b"existing content"), save=False)
+        existing.save()
 
         mock_client = MagicMock()
         mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
@@ -249,8 +253,10 @@ class TestPayloadExtractionJob(CustomTestCase):
     @patch("greedybear.cronjobs.payload_extraction.HttpClient")
     def test_mixed_new_and_existing_payloads(self, mock_http_class, mock_usage):
         """Job should only download payloads not already in the database."""
-        # Pre-create one payload.
-        HoneypotPayload.objects.create(sha256="a" * 64)
+        # Pre-create one payload with a real file - stubs are not "existing" anymore.
+        existing = HoneypotPayload.objects.create(sha256="a" * 64)
+        existing.payload_file.save("existing.vir", ContentFile(b"existing content"), save=False)
+        existing.save()
 
         mock_client = MagicMock()
         mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
@@ -407,7 +413,9 @@ class TestPayloadExtractionJob(CustomTestCase):
     @patch("greedybear.cronjobs.payload_extraction.HttpClient")
     def test_uppercase_hash_matches_existing_lowercase_row(self, mock_http_class, mock_usage):
         """An uppercase hash from the server must not re-insert a known payload."""
-        HoneypotPayload.objects.create(sha256="a" * 64)
+        existing = HoneypotPayload.objects.create(sha256="a" * 64)
+        existing.payload_file.save("existing.vir", ContentFile(b"existing content"), save=False)
+        existing.save()
 
         mock_client = MagicMock()
         mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
@@ -435,7 +443,9 @@ class TestPayloadExtractionJob(CustomTestCase):
     @patch("greedybear.cronjobs.payload_extraction.HttpClient")
     def test_lowercase_hash_matches_existing_uppercase_row(self, mock_http_class, mock_usage):
         """Rows stored in upper case before the fix must still be matched."""
-        HoneypotPayload.objects.create(sha256="B" * 64)
+        existing = HoneypotPayload.objects.create(sha256="B" * 64)
+        existing.payload_file.save("existing.vir", ContentFile(b"existing content"), save=False)
+        existing.save()
 
         mock_client = MagicMock()
         mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
@@ -511,6 +521,115 @@ class TestPayloadExtractionJob(CustomTestCase):
         self.assertEqual(HoneypotPayload.objects.get().sha256, "d" * 64)
         # One metadata request plus exactly one download.
         self.assertEqual(mock_client.get.call_count, 2)
+
+    # Stub-aware deduplication (see issue #1530).
+    # A HoneypotPayload row can exist without a file - a metadata-only stub
+    # created from a raw event before the file itself was ever downloaded.
+    # Such a row must not block the real download, and downloading it must
+    # upgrade the existing row rather than fail on the unique sha256 constraint.
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="",
+        MAX_QUARANTINE_SIZE_GB=5,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_hash_only_stub_is_not_treated_as_duplicate(self, mock_http_class, mock_usage):
+        """A stub row with no payload_file must still be downloaded, not skipped."""
+        stub = HoneypotPayload.objects.create(sha256="e" * 64)
+        stub.refresh_from_db()
+        self.assertEqual(stub.payload_file.name, "")
+
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [
+            {"sha256": "e" * 64, "locator": "cowrie/eee"},
+        ]
+        mock_download_resp = Mock()
+        mock_download_resp.content = b"\xca\xfe"
+        mock_client.get.side_effect = [mock_metadata_resp, mock_download_resp]
+        mock_usage.return_value = 0
+
+        self.job.run()
+
+        # Metadata fetch plus a real download attempt, not skipped as a duplicate.
+        self.assertEqual(mock_client.get.call_count, 2)
+        self.assertEqual(HoneypotPayload.objects.count(), 1)
+        payload = HoneypotPayload.objects.get()
+        self.assertNotEqual(payload.payload_file, "")
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="",
+        MAX_QUARANTINE_SIZE_GB=5,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_downloading_a_stub_upgrades_the_same_row(self, mock_http_class, mock_usage):
+        """Downloading a known stub must update its row, not raise IntegrityError."""
+        stub = HoneypotPayload.objects.create(sha256="f" * 64, md5="", mime_type="")
+
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [
+            {"sha256": "f" * 64, "locator": "cowrie/fff", "md5": "1" * 32, "mime_type": "application/x-elf"},
+        ]
+        mock_download_resp = Mock()
+        mock_download_resp.content = b"\xfe\xed\xfa\xce"
+        mock_client.get.side_effect = [mock_metadata_resp, mock_download_resp]
+        mock_usage.return_value = 0
+
+        self.job.run()
+
+        # No IntegrityError, and the existing row was upgraded rather than duplicated.
+        self.assertEqual(HoneypotPayload.objects.count(), 1)
+        stub.refresh_from_db()
+        self.assertEqual(stub.md5, "1" * 32)
+        self.assertEqual(stub.mime_type, "application/x-elf")
+        self.assertEqual(stub.size, len(b"\xfe\xed\xfa\xce"))
+        self.assertNotEqual(stub.payload_file, "")
+
+    @override_settings(
+        TPOT_PAYLOAD_SERVER_URL="http://payload-server:8000",
+        TPOT_PAYLOAD_SERVER_API_KEY="",
+        MAX_QUARANTINE_SIZE_GB=5,
+    )
+    @patch("greedybear.cronjobs.payload_extraction.PayloadExtractionJob._quarantine_usage_bytes")
+    @patch("greedybear.cronjobs.payload_extraction.HttpClient")
+    def test_downloading_a_stub_upgrades_it_even_with_different_case(self, mock_http_class, mock_usage):
+        """A stub stored in a different case than the incoming hash must still be matched."""
+        stub = HoneypotPayload.objects.create(sha256="G" * 64)
+
+        mock_client = MagicMock()
+        mock_http_class.return_value.__enter__ = Mock(return_value=mock_client)
+        mock_http_class.return_value.__exit__ = Mock(return_value=False)
+
+        mock_metadata_resp = Mock()
+        mock_metadata_resp.json.return_value = [
+            {"sha256": "g" * 64, "locator": "cowrie/ggg", "md5": "2" * 32},
+        ]
+        mock_download_resp = Mock()
+        mock_download_resp.content = b"\x00\x01"
+        mock_client.get.side_effect = [mock_metadata_resp, mock_download_resp]
+        mock_usage.return_value = 0
+
+        self.job.run()
+
+        # No IntegrityError from inserting a differently-cased duplicate of the stub.
+        # The existing row's sha256 casing is left as-is; only the fields carried
+        # in the download response are refreshed.
+        self.assertEqual(HoneypotPayload.objects.count(), 1)
+        stub.refresh_from_db()
+        self.assertEqual(stub.sha256, "G" * 64)
+        self.assertEqual(stub.md5, "2" * 32)
+        self.assertNotEqual(stub.payload_file, "")
 
 
 class TestExtractAllPayloadIntegration(CustomTestCase):


### PR DESCRIPTION
# Description

`PayloadExtractionJob` was skipping any hash that already had a `HoneypotPayload` row, even if that row was just a metadata-only stub (no file yet) created by the event pipeline. Those stubs never had their file attached since dedup treated an existing record as one with the file already downloaded.

Now dedup only counts a hash as "already downloaded" if the row has a real file attached. Stub-only hashes are treated as new and go through the normal download flow, and `_download_and_store` now finds-and-updates an existing stub instead of blindly constructing a new row, so it doesn't hit the unique constraint on `sha256` when one already exists.

### Related issues

Closes #1530

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about how to Contribute to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the docs. If so, I also included an update to the wiki in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

# Note
Instead of `get_or_create`, I used an explicit case-insensitive lookup (because the unique constraint is on `Lower(sha256)`, not the raw column) which might be overkill. I did it because I wanted the Extraction Job to not be dependent on the writes to sha256 always being lower cased (especially in cases where it could have been added from Django Admin).